### PR TITLE
quote directories names

### DIFF
--- a/debian/asterisk.postinst
+++ b/debian/asterisk.postinst
@@ -29,7 +29,7 @@ case "$1" in
 	     /var/lib/asterisk \
 	     -type d | while read dir; do
 		if ! dpkg-statoverride --list "$dir" > /dev/null ; then
-			chown asterisk: $dir
+			chown asterisk: "$dir"
 		fi
 	done 
 	
@@ -45,8 +45,8 @@ case "$1" in
 	# spool holds some sensitive information (e.g. monitor, voicemail etc.)
 	find /var/spool/asterisk -type d | while read dir; do
 		if ! dpkg-statoverride --list "$dir" > /dev/null ; then
-			chown asterisk: $dir
-			chmod 750 $dir
+			chown asterisk: "$dir"
+			chmod 750 "$dir"
 		fi
 	done
 


### PR DESCRIPTION
Should fix this upgrade issue:

```
chown: cannot access '/var/spool/asterisk/voicemail/XXXXXXX': No such file or directory
chown: cannot access 'XXXXXXX-keyYYYY-internal': No such file or directory
dpkg: error processing package asterisk (--configure):
 subprocess installed post-installation script returned error exit status 1
dpkg: dependency problems prevent configuration of wazo-libsccp:
 wazo-libsccp depends on asterisk (>= 8:16) | asterisk-virtual; however:
  Package asterisk is not configured yet.
  Package asterisk-virtual is not installed.

dpkg: error processing package wazo-libsccp (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of xivo-agid:
 xivo-agid depends on asterisk | asterisk-virtual; however:
  Package asterisk is not configured yet.
  Package asterisk-virtual is not installed.

dpkg: error processing package xivo-agid (--configure):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Errors were encountered while processing:
 asterisk
 wazo-libsccp
 xivo-agid
E: Sub-process /usr/bin/dpkg returned an error code (1)
```