### PR TITLE
[WAZO-4398] asterisk 23.2.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:23.2.0-1~wazo) wazo-dev-bookworm; urgency=medium
+
+  * asterisk 23.2.0
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Fri, 23 Jan 2026 15:14:04 -0500
+
 asterisk (8:22.6.0-1~wazo3) wazo-dev-bookworm; urgency=medium
 
   * create fax directory

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-22.6.0/contrib/scripts/astgenkey
+Index: asterisk-23.2.0/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-22.6.0.orig/contrib/scripts/astgenkey
-+++ asterisk-22.6.0/contrib/scripts/astgenkey
+--- asterisk-23.2.0.orig/contrib/scripts/astgenkey
++++ asterisk-23.2.0/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,11 +3,11 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-22.6.0/Makefile
+Index: asterisk-23.2.0/Makefile
 ===================================================================
---- asterisk-22.6.0.orig/Makefile
-+++ asterisk-22.6.0/Makefile
-@@ -443,7 +443,6 @@ dist-clean: distclean
+--- asterisk-23.2.0.orig/Makefile
++++ asterisk-23.2.0/Makefile
+@@ -447,7 +447,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	@$(MAKE) -C menuselect dist-clean
@@ -15,7 +15,7 @@ Index: asterisk-22.6.0/Makefile
  	rm -f menuselect.makeopts makeopts menuselect-tree menuselect.makedeps
  	rm -f config.log config.status config.cache
  	rm -rf autom4te.cache
-@@ -453,6 +452,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
+@@ -457,6 +456,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	rm -f doc/Doxyfile
  	rm -f build_tools/menuselect-deps
  

--- a/debian/patches/expose-app-queues-mutex
+++ b/debian/patches/expose-app-queues-mutex
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -2212,6 +2212,9 @@ static int op_value_get(struct op_value
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -2172,6 +2172,9 @@ static int op_value_get(struct op_value
  static void op_value_set(struct op_value *op_value, int value);
  static void op_value_undef(struct op_value *op_value);
  
@@ -12,7 +12,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  /*! \brief sets the QUEUESTATUS channel variable */
  static void set_queue_result(struct ast_channel *chan, enum queue_result res)
  {
-@@ -13466,6 +13469,11 @@ static void op_value_undef(struct op_val
+@@ -13383,6 +13386,11 @@ static void op_value_undef(struct op_val
  	op_value->defined = 0;
  }
  
@@ -24,7 +24,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  static struct ast_cli_entry cli_queue[] = {
  	AST_CLI_DEFINE(queue_show, "Show status of a specified queue"),
  	AST_CLI_DEFINE(handle_queue_rule_show, "Show the rules defined in queuerules.conf"),
-@@ -13712,7 +13720,7 @@ static int load_module(void)
+@@ -13627,7 +13635,7 @@ static int load_module(void)
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -33,10 +33,10 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
  	.unload = unload_module,
-Index: asterisk-22.6.0/apps/app_queue.exports.in
+Index: asterisk-23.2.0/apps/app_queue.exports.in
 ===================================================================
 --- /dev/null
-+++ asterisk-22.6.0/apps/app_queue.exports.in
++++ asterisk-23.2.0/apps/app_queue.exports.in
 @@ -0,0 +1,6 @@
 +{
 +	global:

--- a/debian/patches/fix-application-playback-update
+++ b/debian/patches/fix-application-playback-update
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/res/res_stasis_playback.c
+Index: asterisk-23.2.0/res/res_stasis_playback.c
 ===================================================================
---- asterisk-22.6.0.orig/res/res_stasis_playback.c
-+++ asterisk-22.6.0/res/res_stasis_playback.c
+--- asterisk-23.2.0.orig/res/res_stasis_playback.c
++++ asterisk-23.2.0/res/res_stasis_playback.c
 @@ -344,7 +344,8 @@ static void play_on_channel(struct stasi
  			if (!recording) {
  				ast_log(LOG_ERROR, "Attempted to play recording '%s' on channel '%s' but recording does not exist",

--- a/debian/patches/fix-invalid-moh
+++ b/debian/patches/fix-invalid-moh
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/res/res_musiconhold.c
+Index: asterisk-23.2.0/res/res_musiconhold.c
 ===================================================================
---- asterisk-22.6.0.orig/res/res_musiconhold.c
-+++ asterisk-22.6.0/res/res_musiconhold.c
+--- asterisk-23.2.0.orig/res/res_musiconhold.c
++++ asterisk-23.2.0/res/res_musiconhold.c
 @@ -413,7 +413,9 @@ static int moh_files_next(struct ast_cha
  		state->samples = 0;
  	}

--- a/debian/patches/fix-queue-deadlock
+++ b/debian/patches/fix-queue-deadlock
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -1991,6 +1991,15 @@ struct skills_group {
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -1951,6 +1951,15 @@ struct skills_group {
  
  static AST_LIST_HEAD_STATIC(skills_groups, skills_group);
  
@@ -18,7 +18,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  struct member {
  	char interface[AST_CHANNEL_NAME];    /*!< Technology/Location to dial to reach this member*/
  	char state_exten[AST_MAX_EXTENSION]; /*!< Extension to get state from (if using hint) */
-@@ -2019,6 +2028,7 @@ struct member {
+@@ -1979,6 +1988,7 @@ struct member {
  	unsigned int delme:1;                /*!< Flag to delete entry on reload */
  	char rt_uniqueid[80];                /*!< Unique id of realtime member entry */
  	unsigned int ringinuse:1;            /*!< Flag to ring queue members even if their status is 'inuse' */
@@ -26,7 +26,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  };
  
  enum empty_conditions {
-@@ -2172,6 +2182,18 @@ static AST_LIST_HEAD_STATIC(rule_lists,
+@@ -2132,6 +2142,18 @@ static AST_LIST_HEAD_STATIC(rule_lists,
  
  static struct ao2_container *queues;
  
@@ -45,7 +45,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  static void update_realtime_members(struct call_queue *q);
  static struct member *interface_exists(struct call_queue *q, const char *interface);
  static int set_member_paused(const char *queuename, const char *interface, const char *reason, int paused);
-@@ -2736,11 +2758,11 @@ static struct ast_json *queue_member_blo
+@@ -2696,11 +2718,11 @@ static struct ast_json *queue_member_blo
  		"StateInterface", mem->state_interface,
  		"Membership", (mem->dynamic ? "dynamic" : (mem->realtime ? "realtime" : "static")),
  		"Penalty", mem->penalty,
@@ -60,7 +60,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		"Status", mem->status,
  		"Paused", mem->paused,
  		"PausedReason", mem->reason_paused,
-@@ -2822,11 +2844,11 @@ static int get_member_status(struct call
+@@ -2782,11 +2804,11 @@ static int get_member_status(struct call
  				ast_debug(4, "%s is unavailable because he is paused'\n", member->membername);
  				break;
  			} else if ((conditions & QUEUE_EMPTY_WRAPUP)
@@ -75,7 +75,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				break;
  			} else {
  				ao2_ref(member, -1);
-@@ -2926,7 +2948,7 @@ static void update_status(struct call_qu
+@@ -2886,7 +2908,7 @@ static void update_status(struct call_qu
  		 * considered done and the call finished.
  		 */
  		if (status == AST_DEVICE_NOT_INUSE) {
@@ -84,7 +84,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		}
  
  		m->status = status;
-@@ -2954,6 +2976,7 @@ static int is_member_available(struct ca
+@@ -2914,6 +2936,7 @@ static int is_member_available(struct ca
  {
  	int available = 0;
  	int wrapuptime;
@@ -92,7 +92,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  	switch (mem->status) {
  		case AST_DEVICE_INVALID:
-@@ -2979,7 +3002,8 @@ static int is_member_available(struct ca
+@@ -2939,7 +2962,8 @@ static int is_member_available(struct ca
  
  	/* Let wrapuptimes override device state availability */
  	wrapuptime = get_wrapuptime(q, mem);
@@ -102,7 +102,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		available = 0;
  	}
  	return available;
-@@ -3207,12 +3231,28 @@ static void destroy_queue_member_cb(void
+@@ -3167,12 +3191,28 @@ static void destroy_queue_member_cb(void
  	if (mem->state_id != -1) {
  		ast_extension_state_del(mem->state_id, extension_state_cb);
  	}
@@ -132,7 +132,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  	if ((cur = ao2_alloc(sizeof(*cur), destroy_queue_member_cb))) {
  		cur->ringinuse = ringinuse;
-@@ -3253,6 +3293,34 @@ static struct member *create_queue_membe
+@@ -3213,6 +3253,34 @@ static struct member *create_queue_membe
  			ast_copy_string(cur->skills, skills, sizeof(cur->skills));
  		else
  			cur->skills[0] = '\0';
@@ -167,7 +167,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	}
  
  	return cur;
-@@ -3413,10 +3481,10 @@ static void clear_queue(struct call_queu
+@@ -3373,10 +3441,10 @@ static void clear_queue(struct call_queu
  		struct member *mem;
  		struct ao2_iterator mem_iter = ao2_iterator_init(q->members, 0);
  		while ((mem = ao2_iterator_next(&mem_iter))) {
@@ -182,7 +182,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			ao2_ref(mem, -1);
  		}
  		ao2_iterator_destroy(&mem_iter);
-@@ -5074,6 +5142,7 @@ static int member_status_available(int s
+@@ -5034,6 +5102,7 @@ static int member_status_available(int s
  static int can_ring_entry(struct queue_ent *qe, struct callattempt *call, int *busies)
  {
  	struct member *memberp = call->member;
@@ -190,7 +190,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int wrapuptime;
  
  	if (memberp->paused) {
-@@ -5086,14 +5155,14 @@ static int can_ring_entry(struct queue_e
+@@ -5046,14 +5115,14 @@ static int can_ring_entry(struct queue_e
  		return 0;
  	}
  
@@ -209,7 +209,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			call->interface);
  		return 0;
  	}
-@@ -5556,8 +5625,8 @@ static void rna(int rnatime, struct queu
+@@ -5516,8 +5585,8 @@ static void rna(int rnatime, struct queu
  			struct member *mem;
  			ao2_lock(qe->parent);
  			if ((mem = interface_exists(qe->parent, interface))) {
@@ -220,7 +220,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  					ao2_unlock(qe->parent);
  					ao2_ref(mem, -1);
  					return;
-@@ -6397,6 +6466,141 @@ static int wait_our_turn(struct queue_en
+@@ -6357,6 +6426,141 @@ static int wait_our_turn(struct queue_en
  }
  
  /*!
@@ -362,7 +362,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
   * \brief update the queue status
   * \retval 0 always
  */
-@@ -6404,43 +6608,23 @@ static int update_queue(struct call_queu
+@@ -6364,43 +6568,23 @@ static int update_queue(struct call_queu
  {
  	int oldtalktime;
  	int newtalktime = time(NULL) - starttime;
@@ -415,7 +415,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	/* Member might never experience any direct status change (local
  	 * channel with forwarding in particular). If that's the case,
  	 * this is the last chance to remove it from pending or subsequent
-@@ -6532,14 +6716,14 @@ static int calc_metric(struct call_queue
+@@ -6492,14 +6676,14 @@ static int calc_metric(struct call_queue
  		tmp->metric = ast_random() % ((1 + penalty) * 1000);
  		break;
  	case QUEUE_STRATEGY_FEWESTCALLS:
@@ -433,7 +433,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		}
  		tmp->metric += penalty * 1000000 * usepenalty;
  		break;
-@@ -7626,7 +7810,8 @@ static int try_calling(struct queue_ent
+@@ -7594,7 +7778,8 @@ static int try_calling(struct queue_ent
  		recalc_holdtime(qe, (now - qe->start));
  		member = lpeer->member;
  		ao2_lock(qe->parent);
@@ -443,7 +443,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		ao2_unlock(qe->parent);
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
-@@ -7735,7 +7920,7 @@ static int try_calling(struct queue_ent
+@@ -7703,7 +7888,7 @@ static int try_calling(struct queue_ent
  		/* use  pbx_builtin_setvar to set a load of variables with one call */
  		if (qe->parent->setinterfacevar && interfacevar) {
  			ast_str_set(&interfacevar, 0, "MEMBERINTERFACE=%s,MEMBERNAME=%s,MEMBERCALLS=%d,MEMBERLASTCALL=%ld,MEMBERPENALTY=%d,MEMBERDYNAMIC=%d,MEMBERREALTIME=%d",
@@ -452,7 +452,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			pbx_builtin_setvar_multiple(qe->chan, ast_str_buffer(interfacevar));
  			pbx_builtin_setvar_multiple(peer, ast_str_buffer(interfacevar));
  		}
-@@ -7859,8 +8044,8 @@ static int try_calling(struct queue_ent
+@@ -7827,8 +8012,8 @@ static int try_calling(struct queue_ent
  		}
  
  		ao2_lock(qe->parent);
@@ -463,7 +463,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		ao2_unlock(qe->parent);
  		/* As a queue member may end up in multiple calls at once if a transfer occurs with
  		 * a Local channel in the mix we pass the current call information (starttime) to the
-@@ -9593,7 +9778,7 @@ static int queue_function_mem_read(struc
+@@ -9560,7 +9745,7 @@ static int queue_function_mem_read(struc
  			while ((m = ao2_iterator_next(&mem_iter))) {
  				/* Count the agents who are logged in, not paused and not wrapping up */
  				if ((m->status == AST_DEVICE_NOT_INUSE) && (!m->paused) &&
@@ -472,7 +472,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  					count++;
  				}
  				ao2_ref(m, -1);
-@@ -10267,8 +10452,8 @@ static void reload_single_member(const c
+@@ -10184,8 +10369,8 @@ static void reload_single_member(const c
  			/* Round Robin Queue Position must be copied if this is replacing an existing member */
  			newm->queuepos = cur->queuepos;
  			/* Don't reset agent stats either */
@@ -483,7 +483,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  			ao2_link(q->members, newm);
  			ao2_unlink(q->members, cur);
-@@ -10647,7 +10832,7 @@ static void print_queue(struct mansessio
+@@ -10564,7 +10749,7 @@ static void print_queue(struct mansessio
  			ast_str_append(&out, 0, "%s%s%s%s%s%s%s%s%s",
  				mem->dynamic ? ast_term_color(COLOR_CYAN, COLOR_BLACK) : "", mem->dynamic ? " (dynamic)" : "", ast_term_reset(),
  				mem->realtime ? ast_term_color(COLOR_MAGENTA, COLOR_BLACK) : "", mem->realtime ? " (realtime)" : "", ast_term_reset(),
@@ -492,7 +492,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  			if (mem->paused) {
  				ast_str_append(&out, 0, " %s(paused%s%s was %ld secs ago)%s",
-@@ -10665,9 +10850,9 @@ static void print_queue(struct mansessio
+@@ -10582,9 +10767,9 @@ static void print_queue(struct mansessio
  					ast_devstate2str(mem->status), ast_term_reset());
  			if (!ast_strlen_zero(mem->skills))
  				ast_str_append(&out, 0, " (skills: %s)", mem->skills);
@@ -504,7 +504,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			} else {
  				ast_str_append(&out, 0, " has taken no calls yet");
  			}
-@@ -11165,7 +11350,7 @@ static int manager_queues_status(struct
+@@ -11082,7 +11267,7 @@ static int manager_queues_status(struct
  						"%s"
  						"\r\n",
  						q->name, mem->membername, mem->interface, mem->state_interface, mem->dynamic ? "dynamic" : "static",
@@ -513,7 +513,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  						mem->paused, mem->reason_paused, mem->wrapuptime, mem->skills, idText);
  					++q_items;
  				}
-@@ -12264,17 +12449,16 @@ static int qupd_exec(struct ast_channel
+@@ -12181,17 +12366,16 @@ static int qupd_exec(struct ast_channel
  				if (!strcasecmp(args.status, "ANSWER")) {
  					oldtalktime = q->talktime;
  					q->talktime = (((oldtalktime << 2) - oldtalktime) + newtalktime) >> 2;

--- a/debian/patches/increase-max-sdp-media
+++ b/debian/patches/increase-max-sdp-media
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/third-party/pjproject/patches/config_site.h
+Index: asterisk-23.2.0/third-party/pjproject/patches/config_site.h
 ===================================================================
---- asterisk-22.6.0.orig/third-party/pjproject/patches/config_site.h
-+++ asterisk-22.6.0/third-party/pjproject/patches/config_site.h
+--- asterisk-23.2.0.orig/third-party/pjproject/patches/config_site.h
++++ asterisk-23.2.0/third-party/pjproject/patches/config_site.h
 @@ -87,7 +87,7 @@
  #define	PJMEDIA_MAX_SDP_FMT   72
  #define	PJMEDIA_MAX_SDP_BANDW   4

--- a/debian/patches/mix_monitor_announce_file
+++ b/debian/patches/mix_monitor_announce_file
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/apps/app_mixmonitor.c
+Index: asterisk-23.2.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_mixmonitor.c
-+++ asterisk-22.6.0/apps/app_mixmonitor.c
+--- asterisk-23.2.0.orig/apps/app_mixmonitor.c
++++ asterisk-23.2.0/apps/app_mixmonitor.c
 @@ -147,10 +147,14 @@
  						<para>Stores the MixMonitor's ID on this channel variable.</para>
  					</option>
@@ -19,7 +19,7 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  					</option>
  					<option name="m">
  						<argument name="mailbox" required="true" />
-@@ -415,6 +419,8 @@ struct mixmonitor {
+@@ -424,6 +428,8 @@ struct mixmonitor {
  	char *filename;
  	char *filename_read;
  	char *filename_write;
@@ -28,16 +28,16 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  	char *post_process;
  	char *name;
  	ast_callid callid;
-@@ -468,6 +474,8 @@ enum mixmonitor_args {
- 	OPT_ARG_BEEP_INTERVAL,
+@@ -482,6 +488,8 @@ enum mixmonitor_args {
  	OPT_ARG_DEPRECATED_RWSYNC,
  	OPT_ARG_NO_RWSYNC,
+ 	OPT_ARG_SKIP,
 +	OPT_ARG_START_SOUND,
 +	OPT_ARG_STOP_SOUND,
  	OPT_ARG_ARRAY_SIZE,	/* Always last element of the enum */
  };
  
-@@ -477,8 +485,8 @@ AST_APP_OPTIONS(mixmonitor_opts, {
+@@ -491,8 +499,8 @@ AST_APP_OPTIONS(mixmonitor_opts, {
  	AST_APP_OPTION_ARG('B', MUXFLAG_BEEP, OPT_ARG_BEEP_INTERVAL),
  	AST_APP_OPTION('c', MUXFLAG_REAL_CALLERID),
  	AST_APP_OPTION('d', MUXFLAG_AUTO_DELETE),
@@ -48,7 +48,7 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  	AST_APP_OPTION_ARG('v', MUXFLAG_READVOLUME, OPT_ARG_READVOLUME),
  	AST_APP_OPTION_ARG('V', MUXFLAG_WRITEVOLUME, OPT_ARG_WRITEVOLUME),
  	AST_APP_OPTION_ARG('W', MUXFLAG_VOLUME, OPT_ARG_VOLUME),
-@@ -666,6 +674,8 @@ static void mixmonitor_free(struct mixmo
+@@ -681,6 +689,8 @@ static void mixmonitor_free(struct mixmo
  		ast_free(mixmonitor->filename);
  		ast_free(mixmonitor->filename_write);
  		ast_free(mixmonitor->filename_read);
@@ -57,7 +57,7 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  
  		/* Free everything in the recipient list */
  		clear_mixmonitor_recipient_list(mixmonitor);
-@@ -905,7 +915,7 @@ static void *mixmonitor_thread(void *obj
+@@ -945,7 +955,7 @@ frame_cleanup:
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {
  		ast_autochan_channel_lock(mixmonitor->autochan);
@@ -66,7 +66,7 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
  		}
  		ast_autochan_channel_unlock(mixmonitor->autochan);
-@@ -998,7 +1008,7 @@ static int setup_mixmonitor_ds(struct mi
+@@ -1038,7 +1048,7 @@ static int setup_mixmonitor_ds(struct mi
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_START)) {
  		ast_autochan_channel_lock(mixmonitor->autochan);
@@ -75,19 +75,19 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  			ast_closestream(ast_channel_stream(mixmonitor->autochan->chan));
  		}
  		ast_autochan_channel_unlock(mixmonitor->autochan);
-@@ -1041,8 +1051,9 @@ static void mixmonitor_ds_remove_and_fre
+@@ -1079,8 +1089,9 @@ static void mixmonitor_ds_remove_and_fre
  static int launch_monitor_thread(struct ast_channel *chan, const char *filename,
  				  unsigned int flags, int readvol, int writevol,
  				  const char *post_process, const char *filename_write,
 -				  char *filename_read, const char *uid_channel_var,
--				  const char *recipients, const char *beep_id)
+-				  const char *recipients, const char *beep_id, double skip_seconds)
 +				  char *filename_read, const char *start_sound, const char *stop_sound,
 +				  const char *uid_channel_var, const char *recipients,
-+				  const char *beep_id)
++				  const char *beep_id, double skip_seconds)
  {
  	pthread_t thread;
  	struct mixmonitor *mixmonitor;
-@@ -1103,6 +1114,14 @@ static int launch_monitor_thread(struct
+@@ -1142,6 +1153,14 @@ static int launch_monitor_thread(struct
  		mixmonitor->filename_read = ast_strdup(filename_read);
  	}
  
@@ -102,8 +102,8 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  	if (setup_mixmonitor_ds(mixmonitor, chan, &datastore_id, beep_id)) {
  		ast_autochan_destroy(mixmonitor->autochan);
  		mixmonitor_free(mixmonitor);
-@@ -1252,6 +1271,8 @@ static int mixmonitor_exec(struct ast_ch
- 	int x, readvol = 0, writevol = 0;
+@@ -1292,6 +1311,8 @@ static int mixmonitor_exec(struct ast_ch
+ 	double skip_seconds = 0.0;
  	char *filename_read = NULL;
  	char *filename_write = NULL;
 +	char *start_sound = NULL;
@@ -111,7 +111,7 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  	char filename_buffer[1024] = "";
  	char *uid_channel_var = NULL;
  	char beep_id[64] = "";
-@@ -1330,6 +1351,14 @@ static int mixmonitor_exec(struct ast_ch
+@@ -1370,6 +1391,14 @@ static int mixmonitor_exec(struct ast_ch
  			filename_read = ast_strdupa(filename_parse(opts[OPT_ARG_READNAME], filename_buffer, sizeof(filename_buffer)));
  		}
  
@@ -126,7 +126,7 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  		if (ast_test_flag(&flags, MUXFLAG_UID)) {
  			uid_channel_var = opts[OPT_ARG_UID];
  		}
-@@ -1373,6 +1402,8 @@ static int mixmonitor_exec(struct ast_ch
+@@ -1429,6 +1458,8 @@ static int mixmonitor_exec(struct ast_ch
  			args.post_process,
  			filename_write,
  			filename_read,
@@ -134,4 +134,4 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
 +			stop_sound,
  			uid_channel_var,
  			recipients,
- 			beep_id)) {
+ 			beep_id,

--- a/debian/patches/mixmonitor_close_beep_file
+++ b/debian/patches/mixmonitor_close_beep_file
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_mixmonitor.c
+Index: asterisk-23.2.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_mixmonitor.c
-+++ asterisk-22.6.0/apps/app_mixmonitor.c
-@@ -905,7 +905,9 @@ static void *mixmonitor_thread(void *obj
+--- asterisk-23.2.0.orig/apps/app_mixmonitor.c
++++ asterisk-23.2.0/apps/app_mixmonitor.c
+@@ -945,7 +945,9 @@ frame_cleanup:
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {
  		ast_autochan_channel_lock(mixmonitor->autochan);
@@ -13,7 +13,7 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  		ast_autochan_channel_unlock(mixmonitor->autochan);
  	}
  
-@@ -996,7 +998,9 @@ static int setup_mixmonitor_ds(struct mi
+@@ -1036,7 +1038,9 @@ static int setup_mixmonitor_ds(struct mi
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_START)) {
  		ast_autochan_channel_lock(mixmonitor->autochan);

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-22.6.0/res/ari.make
+Index: asterisk-23.2.0/res/ari.make
 ===================================================================
---- asterisk-22.6.0.orig/res/ari.make
-+++ asterisk-22.6.0/res/ari.make
+--- asterisk-23.2.0.orig/res/ari.make
++++ asterisk-23.2.0/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-22.6.0/res/ari/resource_wazo.c
+Index: asterisk-23.2.0/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-22.6.0/res/ari/resource_wazo.c
++++ asterisk-23.2.0/res/ari/resource_wazo.c
 @@ -0,0 +1,417 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -429,10 +429,10 @@ Index: asterisk-22.6.0/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-22.6.0/res/ari/resource_wazo.h
+Index: asterisk-23.2.0/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-22.6.0/res/ari/resource_wazo.h
++++ asterisk-23.2.0/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -634,10 +634,10 @@ Index: asterisk-22.6.0/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-22.6.0/res/res_ari_wazo.c
+Index: asterisk-23.2.0/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-22.6.0/res/res_ari_wazo.c
++++ asterisk-23.2.0/res/res_ari_wazo.c
 @@ -0,0 +1,608 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1247,10 +1247,10 @@ Index: asterisk-22.6.0/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-22.6.0/rest-api/api-docs/wazo.json
+Index: asterisk-23.2.0/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-22.6.0/rest-api/api-docs/wazo.json
++++ asterisk-23.2.0/rest-api/api-docs/wazo.json
 @@ -0,0 +1,296 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1548,10 +1548,10 @@ Index: asterisk-22.6.0/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-22.6.0/rest-api/resources.json
+Index: asterisk-23.2.0/rest-api/resources.json
 ===================================================================
---- asterisk-22.6.0.orig/rest-api/resources.json
-+++ asterisk-22.6.0/rest-api/resources.json
+--- asterisk-23.2.0.orig/rest-api/resources.json
++++ asterisk-23.2.0/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1563,10 +1563,10 @@ Index: asterisk-22.6.0/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-22.6.0/include/asterisk/app.h
+Index: asterisk-23.2.0/include/asterisk/app.h
 ===================================================================
---- asterisk-22.6.0.orig/include/asterisk/app.h
-+++ asterisk-22.6.0/include/asterisk/app.h
+--- asterisk-23.2.0.orig/include/asterisk/app.h
++++ asterisk-23.2.0/include/asterisk/app.h
 @@ -518,6 +518,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1656,10 +1656,10 @@ Index: asterisk-22.6.0/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-22.6.0/main/app.c
+Index: asterisk-23.2.0/main/app.c
 ===================================================================
---- asterisk-22.6.0.orig/main/app.c
-+++ asterisk-22.6.0/main/app.c
+--- asterisk-23.2.0.orig/main/app.c
++++ asterisk-23.2.0/main/app.c
 @@ -736,6 +736,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1719,10 +1719,10 @@ Index: asterisk-22.6.0/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-22.6.0/apps/app_voicemail.c
+Index: asterisk-23.2.0/apps/app_voicemail.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_voicemail.c
-+++ asterisk-22.6.0/apps/app_voicemail.c
+--- asterisk-23.2.0.orig/apps/app_voicemail.c
++++ asterisk-23.2.0/apps/app_voicemail.c
 @@ -713,6 +713,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
@@ -1734,7 +1734,7 @@ Index: asterisk-22.6.0/apps/app_voicemail.c
  #define MAX_DATETIME_FORMAT	512
  #define MAX_NUM_CID_CONTEXTS 10
  
-@@ -1264,6 +1268,13 @@ static int vm_msg_forward(const char *fr
+@@ -1261,6 +1265,13 @@ static int vm_msg_forward(const char *fr
  static int vm_msg_move(const char *mailbox, const char *context, size_t num_msgs, const char *oldfolder, const char *old_msg_ids[], const char *newfolder);
  static int vm_msg_remove(const char *mailbox, const char *context, size_t num_msgs, const char *folder, const char *msgs[]);
  static int vm_msg_play(struct ast_channel *chan, const char *mailbox, const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb cb);
@@ -1748,7 +1748,7 @@ Index: asterisk-22.6.0/apps/app_voicemail.c
  
  #ifdef TEST_FRAMEWORK
  static int vm_test_destroy_user(const char *context, const char *mailbox);
-@@ -16258,6 +16269,10 @@ static const struct ast_vm_functions vm_
+@@ -16136,6 +16147,10 @@ static const struct ast_vm_functions vm_
  	.msg_remove = vm_msg_remove,
  	.msg_forward = vm_msg_forward,
  	.msg_play = vm_msg_play,
@@ -1759,7 +1759,7 @@ Index: asterisk-22.6.0/apps/app_voicemail.c
  };
  
  static const struct ast_vm_greeter_functions vm_greeter_table = {
-@@ -17846,6 +17861,197 @@ play2_msg_cleanup:
+@@ -17724,6 +17739,197 @@ play2_msg_cleanup:
  	return res;
  }
  
@@ -1957,10 +1957,10 @@ Index: asterisk-22.6.0/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-22.6.0/main/http.c
+Index: asterisk-23.2.0/main/http.c
 ===================================================================
---- asterisk-22.6.0.orig/main/http.c
-+++ asterisk-22.6.0/main/http.c
+--- asterisk-23.2.0.orig/main/http.c
++++ asterisk-23.2.0/main/http.c
 @@ -82,7 +82,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */
@@ -1970,11 +1970,11 @@ Index: asterisk-22.6.0/main/http.c
  #else
  #define MAX_CONTENT_LENGTH 1024
  #endif	/* !defined(LOW_MEMORY) */
-Index: asterisk-22.6.0/res/ari/ari_model_validators.c
+Index: asterisk-23.2.0/res/ari/ari_model_validators.c
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/ari_model_validators.c
-+++ asterisk-22.6.0/res/ari/ari_model_validators.c
-@@ -8726,3 +8726,41 @@ ari_validator ast_ari_validate_applicati
+--- asterisk-23.2.0.orig/res/ari/ari_model_validators.c
++++ asterisk-23.2.0/res/ari/ari_model_validators.c
+@@ -8744,3 +8744,41 @@ ari_validator ast_ari_validate_applicati
  {
  	return ast_ari_validate_application;
  }
@@ -2016,10 +2016,10 @@ Index: asterisk-22.6.0/res/ari/ari_model_validators.c
 +{
 +	return ast_ari_validate_encoded_file;
 +}
-Index: asterisk-22.6.0/res/ari/ari_model_validators.h
+Index: asterisk-23.2.0/res/ari/ari_model_validators.h
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/ari_model_validators.h
-+++ asterisk-22.6.0/res/ari/ari_model_validators.h
+--- asterisk-23.2.0.orig/res/ari/ari_model_validators.h
++++ asterisk-23.2.0/res/ari/ari_model_validators.h
 @@ -1503,6 +1503,22 @@ int ast_ari_validate_application(struct
   */
  ari_validator ast_ari_validate_application_fn(void);
@@ -2043,7 +2043,7 @@ Index: asterisk-22.6.0/res/ari/ari_model_validators.h
  /*
   * JSON models
   *
-@@ -2059,6 +2075,8 @@ ari_validator ast_ari_validate_applicati
+@@ -2061,6 +2077,8 @@ ari_validator ast_ari_validate_applicati
   * - events_allowed: List[object] (required)
   * - events_disallowed: List[object] (required)
   * - name: string (required)

--- a/debian/patches/wazo_banner
+++ b/debian/patches/wazo_banner
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/main/asterisk.c
+Index: asterisk-23.2.0/main/asterisk.c
 ===================================================================
---- asterisk-22.6.0.orig/main/asterisk.c
-+++ asterisk-22.6.0/main/asterisk.c
-@@ -314,6 +314,10 @@ int daemon(int, int);  /* defined in lib
+--- asterisk-23.2.0.orig/main/asterisk.c
++++ asterisk-23.2.0/main/asterisk.c
+@@ -315,6 +315,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \
                  "certain conditions. Type 'core show license' for details.\n" \

--- a/debian/patches/wazo_bridge_variables
+++ b/debian/patches/wazo_bridge_variables
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/include/asterisk/bridge.h
+Index: asterisk-23.2.0/include/asterisk/bridge.h
 ===================================================================
---- asterisk-22.6.0.orig/include/asterisk/bridge.h
-+++ asterisk-22.6.0/include/asterisk/bridge.h
+--- asterisk-23.2.0.orig/include/asterisk/bridge.h
++++ asterisk-23.2.0/include/asterisk/bridge.h
 @@ -253,6 +253,31 @@ typedef void (*ast_bridge_notify_masquer
  typedef int (*ast_bridge_merge_priority_fn)(struct ast_bridge *self);
  
@@ -85,10 +85,10 @@ Index: asterisk-22.6.0/include/asterisk/bridge.h
  #if defined(__cplusplus) || defined(c_plusplus)
  }
  #endif
-Index: asterisk-22.6.0/main/bridge.c
+Index: asterisk-23.2.0/main/bridge.c
 ===================================================================
---- asterisk-22.6.0.orig/main/bridge.c
-+++ asterisk-22.6.0/main/bridge.c
+--- asterisk-23.2.0.orig/main/bridge.c
++++ asterisk-23.2.0/main/bridge.c
 @@ -127,6 +127,8 @@
  #include "asterisk/core_local.h"
  #include "asterisk/core_unreal.h"
@@ -151,10 +151,10 @@ Index: asterisk-22.6.0/main/bridge.c
  static int manager_bridge_tech_list(struct mansession *s, const struct message *m)
  {
  	const char *id = astman_get_header(m, "ActionID");
-Index: asterisk-22.6.0/res/ari/resource_bridges.c
+Index: asterisk-23.2.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/resource_bridges.c
-+++ asterisk-22.6.0/res/ari/resource_bridges.c
+--- asterisk-23.2.0.orig/res/ari/resource_bridges.c
++++ asterisk-23.2.0/res/ari/resource_bridges.c
 @@ -44,6 +44,10 @@
  #include "asterisk/file.h"
  #include "asterisk/musiconhold.h"
@@ -166,7 +166,7 @@ Index: asterisk-22.6.0/res/ari/resource_bridges.c
  
  /*!
   * \brief Finds a bridge, filling the response with an error, if appropriate.
-@@ -1081,3 +1085,120 @@ void ast_ari_bridges_clear_video_source(
+@@ -1152,3 +1156,120 @@ void ast_ari_bridges_clear_video_source(
  	ao2_ref(bridge, -1);
  	ast_ari_response_no_content(response);
  }
@@ -288,11 +288,11 @@ Index: asterisk-22.6.0/res/ari/resource_bridges.c
 +	ast_ari_response_ok(response, response->message);
 +}
 \ No newline at end of file
-Index: asterisk-22.6.0/res/ari/resource_bridges.h
+Index: asterisk-23.2.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/resource_bridges.h
-+++ asterisk-22.6.0/res/ari/resource_bridges.h
-@@ -395,5 +395,59 @@ int ast_ari_bridges_record_parse_body(
+--- asterisk-23.2.0.orig/res/ari/resource_bridges.h
++++ asterisk-23.2.0/res/ari/resource_bridges.h
+@@ -401,5 +401,59 @@ int ast_ari_bridges_record_parse_body(
   * \param[out] response HTTP response
   */
  void ast_ari_bridges_record(struct ast_variable *headers, struct ast_ari_bridges_record_args *args, struct ast_ari_response *response);
@@ -352,11 +352,11 @@ Index: asterisk-22.6.0/res/ari/resource_bridges.h
 +void ast_ari_bridges_set_bridge_var(struct ast_variable *headers, struct ast_ari_bridges_set_bridge_var_args *args, struct ast_ari_response *response);
  
  #endif /* _ASTERISK_RESOURCE_BRIDGES_H */
-Index: asterisk-22.6.0/res/res_ari_bridges.c
+Index: asterisk-23.2.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-22.6.0.orig/res/res_ari_bridges.c
-+++ asterisk-22.6.0/res/res_ari_bridges.c
-@@ -1491,6 +1491,179 @@ static void ast_ari_bridges_record_cb(
+--- asterisk-23.2.0.orig/res/res_ari_bridges.c
++++ asterisk-23.2.0/res/res_ari_bridges.c
+@@ -1514,6 +1514,179 @@ static void ast_ari_bridges_record_cb(
  fin: __attribute__((unused))
  	return;
  }
@@ -536,7 +536,7 @@ Index: asterisk-22.6.0/res/res_ari_bridges.c
  
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges_bridgeId_addChannel = {
-@@ -1568,6 +1741,16 @@ static struct stasis_rest_handlers bridg
+@@ -1591,6 +1764,16 @@ static struct stasis_rest_handlers bridg
  	.children = {  }
  };
  /*! \brief REST handler for /api-docs/bridges.json */
@@ -553,7 +553,7 @@ Index: asterisk-22.6.0/res/res_ari_bridges.c
  static struct stasis_rest_handlers bridges_bridgeId = {
  	.path_segment = "bridgeId",
  	.is_wildcard = 1,
-@@ -1576,8 +1759,8 @@ static struct stasis_rest_handlers bridg
+@@ -1599,8 +1782,8 @@ static struct stasis_rest_handlers bridg
  		[AST_HTTP_GET] = ast_ari_bridges_get_cb,
  		[AST_HTTP_DELETE] = ast_ari_bridges_destroy_cb,
  	},
@@ -564,19 +564,19 @@ Index: asterisk-22.6.0/res/res_ari_bridges.c
  };
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges = {
-Index: asterisk-22.6.0/rest-api/api-docs/bridges.json
+Index: asterisk-23.2.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-22.6.0.orig/rest-api/api-docs/bridges.json
-+++ asterisk-22.6.0/rest-api/api-docs/bridges.json
-@@ -630,7 +630,6 @@
- 							"reason": "Bridge not in a Stasis application"
+--- asterisk-23.2.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-23.2.0/rest-api/api-docs/bridges.json
+@@ -653,7 +653,6 @@
+ 							"reason": "The format specified is unknown on this system"
  						}
  					]
 -
  				}
  			]
  		},
-@@ -763,6 +762,96 @@
+@@ -794,6 +793,96 @@
                      ]
  				}
  			]
@@ -673,7 +673,7 @@ Index: asterisk-22.6.0/rest-api/api-docs/bridges.json
  		}
  	],
  	"models": {
-@@ -826,6 +915,11 @@
+@@ -857,6 +946,11 @@
  					"required": true,
  					"type": "Date",
  					"description": "Timestamp when bridge was created"
@@ -685,10 +685,10 @@ Index: asterisk-22.6.0/rest-api/api-docs/bridges.json
  				}
  			}
  		}
-Index: asterisk-22.6.0/include/asterisk/stasis_bridges.h
+Index: asterisk-23.2.0/include/asterisk/stasis_bridges.h
 ===================================================================
---- asterisk-22.6.0.orig/include/asterisk/stasis_bridges.h
-+++ asterisk-22.6.0/include/asterisk/stasis_bridges.h
+--- asterisk-23.2.0.orig/include/asterisk/stasis_bridges.h
++++ asterisk-23.2.0/include/asterisk/stasis_bridges.h
 @@ -103,6 +103,9 @@ struct ast_bridge_merge_message {
  	struct ast_bridge_snapshot *to;		/*!< Bridge to which channels will be added during the merge */
  };
@@ -717,10 +717,10 @@ Index: asterisk-22.6.0/include/asterisk/stasis_bridges.h
   * \brief Blob of data associated with a bridge.
   *
   * The \c blob is actually a JSON object of structured data. It has a "type" field
-Index: asterisk-22.6.0/main/stasis_bridges.c
+Index: asterisk-23.2.0/main/stasis_bridges.c
 ===================================================================
---- asterisk-22.6.0.orig/main/stasis_bridges.c
-+++ asterisk-22.6.0/main/stasis_bridges.c
+--- asterisk-23.2.0.orig/main/stasis_bridges.c
++++ asterisk-23.2.0/main/stasis_bridges.c
 @@ -37,6 +37,7 @@
  #include "asterisk/stasis_channels.h"
  #include "asterisk/bridge.h"
@@ -861,10 +861,10 @@ Index: asterisk-22.6.0/main/stasis_bridges.c
  
  	return res;
  }
-Index: asterisk-22.6.0/rest-api/api-docs/events.json
+Index: asterisk-23.2.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-22.6.0.orig/rest-api/api-docs/events.json
-+++ asterisk-22.6.0/rest-api/api-docs/events.json
+--- asterisk-23.2.0.orig/rest-api/api-docs/events.json
++++ asterisk-23.2.0/rest-api/api-docs/events.json
 @@ -173,6 +173,7 @@
  				"ApplicationUnregistered",
  				"ApplicationReplaced",
@@ -873,7 +873,7 @@ Index: asterisk-22.6.0/rest-api/api-docs/events.json
  				"BridgeDestroyed",
  				"BridgeMerged",
  				"BridgeBlindTransfer",
-@@ -758,6 +759,27 @@
+@@ -766,6 +767,27 @@
  				}
  			}
  		},

--- a/debian/patches/wazo_mixmonitor_events
+++ b/debian/patches/wazo_mixmonitor_events
@@ -1,17 +1,17 @@
-Index: asterisk-22.6.0/apps/app_mixmonitor.c
+Index: asterisk-23.2.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_mixmonitor.c
-+++ asterisk-22.6.0/apps/app_mixmonitor.c
-@@ -1044,6 +1044,8 @@ static int launch_monitor_thread(struct
+--- asterisk-23.2.0.orig/apps/app_mixmonitor.c
++++ asterisk-23.2.0/apps/app_mixmonitor.c
+@@ -1082,6 +1082,8 @@ static int launch_monitor_thread(struct
  	struct mixmonitor *mixmonitor;
  	char postprocess2[1024] = "";
  	char *datastore_id = NULL;
 +	RAII_VAR(struct stasis_message *, message, NULL, ao2_cleanup);
 +	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
-
+ 
  	postprocess2[0] = 0;
  	/* If a post process system command is given attach it to the structure */
-@@ -1181,6 +1183,15 @@ static int launch_monitor_thread(struct
+@@ -1220,6 +1222,15 @@ static int launch_monitor_thread(struct
  		mixmonitor_free(mixmonitor);
  		return -1;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
 +	if (message) {
 +		stasis_publish(ast_channel_topic(chan), message);
 +	}
-
+ 
  	ast_free(datastore_id);
-
-@@ -1244,7 +1255,6 @@ static int mixmonitor_exec(struct ast_ch
+ 
+@@ -1284,7 +1295,6 @@ static int mixmonitor_exec(struct ast_ch
  	struct ast_flags flags = { 0 };
  	char *recipients = NULL;
  	char *parse;
@@ -35,10 +35,10 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  	AST_DECLARE_APP_ARGS(args,
  		AST_APP_ARG(filename);
  		AST_APP_ARG(options);
-@@ -1365,12 +1375,6 @@ static int mixmonitor_exec(struct ast_ch
+@@ -1422,12 +1432,6 @@ static int mixmonitor_exec(struct ast_ch
  		ast_module_unref(ast_module_info->self);
  	}
-
+ 
 -	message = ast_channel_blob_create_from_cache(ast_channel_uniqueid(chan),
 -		ast_channel_mixmonitor_start_type(), NULL);
 -	if (message) {
@@ -47,21 +47,21 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
 -
  	return 0;
  }
-
-@@ -1380,7 +1384,9 @@ static int stop_mixmonitor_full(struct a
+ 
+@@ -1437,7 +1441,9 @@ static int stop_mixmonitor_full(struct a
  	char *parse = "";
  	struct mixmonitor_ds *mixmonitor_ds;
  	const char *beep_id = NULL;
 +	char *datastore_id = NULL;
  	RAII_VAR(struct stasis_message *, message, NULL, ao2_cleanup);
 +	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
-
+ 
  	AST_DECLARE_APP_ARGS(args,
  		AST_APP_ARG(mixmonid);
-@@ -1404,6 +1410,12 @@ static int stop_mixmonitor_full(struct a
-
+@@ -1461,6 +1467,12 @@ static int stop_mixmonitor_full(struct a
+ 
  	ast_mutex_lock(&mixmonitor_ds->lock);
-
+ 
 +	if (ast_asprintf(&datastore_id, "%p", mixmonitor_ds) == -1) {
 +		ast_log(LOG_ERROR, "Failed to allocate memory for MixMonitor ID.\n");
 +		ast_mutex_unlock(&mixmonitor_ds->lock);
@@ -71,10 +71,10 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  	/* closing the filestream here guarantees the file is available to the dialplan
  	 * after calling StopMixMonitor */
  	mixmonitor_ds_close_fs(mixmonitor_ds);
-@@ -1438,13 +1450,17 @@ static int stop_mixmonitor_full(struct a
+@@ -1495,13 +1507,17 @@ static int stop_mixmonitor_full(struct a
  		ast_beep_stop(chan, beep_id);
  	}
-
+ 
 +	blob = ast_json_pack("{s: s}",
 +		"mixmonitor_id", datastore_id);
  	message = ast_channel_blob_create_from_cache(ast_channel_uniqueid(chan),
@@ -85,16 +85,16 @@ Index: asterisk-22.6.0/apps/app_mixmonitor.c
  	if (message) {
  		stasis_publish(ast_channel_topic(chan), message);
  	}
-
+ 
 +	ast_free(datastore_id);
 +
  	return 0;
  }
-
-Index: asterisk-22.6.0/main/cel.c
+ 
+Index: asterisk-23.2.0/main/cel.c
 ===================================================================
---- asterisk-22.6.0.orig/main/cel.c
-+++ asterisk-22.6.0/main/cel.c
+--- asterisk-23.2.0.orig/main/cel.c
++++ asterisk-23.2.0/main/cel.c
 @@ -344,6 +344,8 @@ static const char * const cel_event_type
  	[AST_CEL_STREAM_BEGIN]     = "STREAM_BEGIN",
  	[AST_CEL_STREAM_END]       = "STREAM_END",
@@ -102,12 +102,12 @@ Index: asterisk-22.6.0/main/cel.c
 +	[AST_CEL_MIXMONITOR_START] = "MIXMONITOR_START",
 +	[AST_CEL_MIXMONITOR_STOP]  = "MIXMONITOR_STOP",
  };
-
+ 
  struct cel_backend {
 @@ -1420,6 +1422,33 @@ static void cel_pickup_cb(
  }
-
-
+ 
+ 
 +static void cel_mixmonitor_start_cb(
 +	void *data, struct stasis_subscription *sub,
 +	struct stasis_message *message)
@@ -140,7 +140,7 @@ Index: asterisk-22.6.0/main/cel.c
  	struct stasis_message *message,
 @@ -1603,6 +1632,16 @@ static int create_routes(void)
  		NULL);
-
+ 
  	ret |= stasis_message_router_add(cel_state_router,
 +		ast_channel_mixmonitor_start_type(),
 +		cel_mixmonitor_start_cb,
@@ -155,10 +155,10 @@ Index: asterisk-22.6.0/main/cel.c
  		ast_local_optimization_end_type(),
  		cel_local_optimization_end_cb,
  		NULL);
-Index: asterisk-22.6.0/include/asterisk/cel.h
+Index: asterisk-23.2.0/include/asterisk/cel.h
 ===================================================================
---- asterisk-22.6.0.orig/include/asterisk/cel.h
-+++ asterisk-22.6.0/include/asterisk/cel.h
+--- asterisk-23.2.0.orig/include/asterisk/cel.h
++++ asterisk-23.2.0/include/asterisk/cel.h
 @@ -83,6 +83,10 @@ enum ast_cel_event_type {
  	AST_CEL_STREAM_END = 20,
  	/*! \brief A DTMF digit was processed */
@@ -168,5 +168,5 @@ Index: asterisk-22.6.0/include/asterisk/cel.h
 +	/*! \brief a MixMonitor has been stopped on this channel */
 +	AST_CEL_MIXMONITOR_STOP = 33,
  };
-
+ 
  /*!

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/res/res_pjsip/location.c
+Index: asterisk-23.2.0/res/res_pjsip/location.c
 ===================================================================
---- asterisk-22.6.0.orig/res/res_pjsip/location.c
-+++ asterisk-22.6.0/res/res_pjsip/location.c
+--- asterisk-23.2.0.orig/res/res_pjsip/location.c
++++ asterisk-23.2.0/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,10 +41,10 @@ Index: asterisk-22.6.0/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-22.6.0/res/res_pjsip_registrar.c
+Index: asterisk-23.2.0/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-22.6.0.orig/res/res_pjsip_registrar.c
-+++ asterisk-22.6.0/res/res_pjsip_registrar.c
+--- asterisk-23.2.0.orig/res/res_pjsip_registrar.c
++++ asterisk-23.2.0/res/res_pjsip_registrar.c
 @@ -625,6 +625,35 @@ static int vec_contact_add(void *obj, vo
  	return 0;
  }
@@ -190,10 +190,10 @@ Index: asterisk-22.6.0/res/res_pjsip_registrar.c
  	response_contact = ao2_callback(contacts, 0, NULL, NULL);
  
  	/* Send a response containing all of the contacts (including static) that are present on this AOR */
-Index: asterisk-22.6.0/include/asterisk/res_pjsip.h
+Index: asterisk-23.2.0/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-22.6.0.orig/include/asterisk/res_pjsip.h
-+++ asterisk-22.6.0/include/asterisk/res_pjsip.h
+--- asterisk-23.2.0.orig/include/asterisk/res_pjsip.h
++++ asterisk-23.2.0/include/asterisk/res_pjsip.h
 @@ -409,6 +409,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
@@ -203,7 +203,7 @@ Index: asterisk-22.6.0/include/asterisk/res_pjsip.h
  	);
  	/*! Absolute time that this contact is no longer valid after */
  	struct timeval expiration_time;
-@@ -1837,7 +1839,7 @@ int ast_sip_location_add_contact_nolock(
+@@ -1849,7 +1851,7 @@ int ast_sip_location_add_contact_nolock(
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
  	const char *user_agent, const char *via_addr, int via_port, const char *call_id,
@@ -212,11 +212,11 @@ Index: asterisk-22.6.0/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-22.6.0/res/res_pjsip/pjsip_config.xml
+Index: asterisk-23.2.0/res/res_pjsip/pjsip_config.xml
 ===================================================================
---- asterisk-22.6.0.orig/res/res_pjsip/pjsip_config.xml
-+++ asterisk-22.6.0/res/res_pjsip/pjsip_config.xml
-@@ -2720,6 +2720,12 @@
+--- asterisk-23.2.0.orig/res/res_pjsip/pjsip_config.xml
++++ asterisk-23.2.0/res/res_pjsip/pjsip_config.xml
+@@ -2735,6 +2735,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>
  				</configOption>

--- a/debian/patches/wazo_stun_recurring_resolution
+++ b/debian/patches/wazo_stun_recurring_resolution
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/main/dns_recurring.c
+Index: asterisk-23.2.0/main/dns_recurring.c
 ===================================================================
---- asterisk-22.6.0.orig/main/dns_recurring.c
-+++ asterisk-22.6.0/main/dns_recurring.c
+--- asterisk-23.2.0.orig/main/dns_recurring.c
++++ asterisk-23.2.0/main/dns_recurring.c
 @@ -41,9 +41,13 @@
  
  /*! \brief Delay between TTL expiration and the next DNS query, to make sure the
@@ -44,10 +44,10 @@ Index: asterisk-22.6.0/main/dns_recurring.c
  		}
  	}
  
-Index: asterisk-22.6.0/res/res_rtp_asterisk.c
+Index: asterisk-23.2.0/res/res_rtp_asterisk.c
 ===================================================================
---- asterisk-22.6.0.orig/res/res_rtp_asterisk.c
-+++ asterisk-22.6.0/res/res_rtp_asterisk.c
+--- asterisk-23.2.0.orig/res/res_rtp_asterisk.c
++++ asterisk-23.2.0/res/res_rtp_asterisk.c
 @@ -228,7 +228,7 @@ static int dtls_mtu = DEFAULT_DTLS_MTU;
  #ifdef HAVE_PJPROJECT
  static int icesupport = DEFAULT_ICESUPPORT;
@@ -93,7 +93,7 @@ Index: asterisk-22.6.0/res/res_rtp_asterisk.c
  #endif
  
  #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
-@@ -3732,7 +3735,7 @@ static void rtp_add_candidates_to_ice(st
+@@ -3745,7 +3748,7 @@ static void rtp_add_candidates_to_ice(st
  	pj_sockaddr pjtmp;
  	struct ast_ice_host_candidate *candidate;
  	int af_inet_ok = 0, af_inet6_ok = 0;
@@ -102,7 +102,7 @@ Index: asterisk-22.6.0/res/res_rtp_asterisk.c
  
  	if (ast_sockaddr_is_ipv4(addr)) {
  		af_inet_ok = 1;
-@@ -3842,9 +3845,7 @@ static void rtp_add_candidates_to_ice(st
+@@ -3855,9 +3858,7 @@ static void rtp_add_candidates_to_ice(st
  		freeifaddrs(ifa);
  	}
  
@@ -113,7 +113,7 @@ Index: asterisk-22.6.0/res/res_rtp_asterisk.c
  
  	/* If configured to use a STUN server to get our external mapped address do so */
  	if (stunaddr_copy.sin_addr.s_addr && !stun_address_is_blacklisted(addr) &&
-@@ -9609,70 +9610,175 @@ static int ast_rtp_bundle(struct ast_rtp
+@@ -9614,70 +9615,175 @@ static int ast_rtp_bundle(struct ast_rtp
  }
  
  #ifdef HAVE_PJPROJECT
@@ -335,7 +335,7 @@ Index: asterisk-22.6.0/res/res_rtp_asterisk.c
  }
  #endif
  
-@@ -9809,10 +9915,9 @@ static char *handle_cli_rtp_settings(str
+@@ -9814,10 +9920,9 @@ static char *handle_cli_rtp_settings(str
  #ifdef HAVE_PJPROJECT
  	ast_cli(a->fd, "  ICE support:     %s\n", AST_CLI_YESNO(icesupport));
  
@@ -349,7 +349,7 @@ Index: asterisk-22.6.0/res/res_rtp_asterisk.c
  #endif
  	return CLI_SUCCESS;
  }
-@@ -10061,7 +10166,8 @@ static int rtp_reload(int reload, int by
+@@ -10066,7 +10171,8 @@ static int rtp_reload(int reload, int by
  	icesupport = DEFAULT_ICESUPPORT;
  	stun_software_attribute = DEFAULT_STUN_SOFTWARE_ATTRIBUTE;
  	turnport = DEFAULT_TURN_PORT;
@@ -359,7 +359,7 @@ Index: asterisk-22.6.0/res/res_rtp_asterisk.c
  	turnaddr = pj_str(NULL);
  	turnusername = pj_str(NULL);
  	turnpassword = pj_str(NULL);
-@@ -10139,36 +10245,8 @@ static int rtp_reload(int reload, int by
+@@ -10144,36 +10250,8 @@ static int rtp_reload(int reload, int by
  		stun_software_attribute = ast_true(s);
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "stunaddr"))) {
@@ -398,7 +398,7 @@ Index: asterisk-22.6.0/res/res_rtp_asterisk.c
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "turnaddr"))) {
  		struct sockaddr_in addr;
-@@ -10434,7 +10512,7 @@ static int unload_module(void)
+@@ -10439,7 +10517,7 @@ static int unload_module(void)
  	acl_change_sub = stasis_unsubscribe_and_join(acl_change_sub);
  	rtp_unload_acl(&ice_acl_lock, &ice_acl);
  	rtp_unload_acl(&stun_acl_lock, &stun_acl);

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -2541,6 +2541,18 @@ static struct ast_manager_event_blob *qu
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -2501,6 +2501,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;
  		}
@@ -21,7 +21,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	}
  
  	agent = ast_multi_channel_blob_get_channel(obj, "agent");
-@@ -6545,13 +6557,14 @@ static void send_agent_complete(const ch
+@@ -6505,13 +6517,14 @@ static void send_agent_complete(const ch
  		break;
  	}
  

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -6528,7 +6528,7 @@ enum agent_complete_reason {
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -6488,7 +6488,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,
  	struct ast_channel_snapshot *peer, const struct member *member, time_t holdstart,
@@ -11,7 +11,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  {
  	const char *reason = NULL;	/* silence dumb compilers */
  	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
-@@ -6545,16 +6545,21 @@ static void send_agent_complete(const ch
+@@ -6505,16 +6505,21 @@ static void send_agent_complete(const ch
  		break;
  	}
  
@@ -34,7 +34,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  }
  
  static void queue_agent_cb(void *userdata, struct stasis_subscription *sub,
-@@ -6849,7 +6854,7 @@ static void handle_blind_transfer(void *
+@@ -6809,7 +6814,7 @@ static void handle_blind_transfer(void *
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -43,7 +43,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -6907,7 +6912,7 @@ static void handle_attended_transfer(voi
+@@ -6867,7 +6872,7 @@ static void handle_attended_transfer(voi
  	log_attended_transfer(queue_data, atxfer_msg);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -52,7 +52,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -7105,7 +7110,7 @@ static void handle_hangup(void *userdata
+@@ -7073,7 +7078,7 @@ static void handle_hangup(void *userdata
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/main/stasis_channels.c
+Index: asterisk-23.2.0/main/stasis_channels.c
 ===================================================================
---- asterisk-22.6.0.orig/main/stasis_channels.c
-+++ asterisk-22.6.0/main/stasis_channels.c
-@@ -1812,6 +1812,47 @@ struct ast_ari_transfer_message *ast_ari
+--- asterisk-23.2.0.orig/main/stasis_channels.c
++++ asterisk-23.2.0/main/stasis_channels.c
+@@ -1823,6 +1823,47 @@ struct ast_ari_transfer_message *ast_ari
  	return msg;
  }
  
@@ -50,7 +50,7 @@ Index: asterisk-22.6.0/main/stasis_channels.c
  /*!
   * @{ \brief Define channel message types.
   */
-@@ -1843,8 +1884,12 @@ STASIS_MESSAGE_TYPE_DEFN(ast_channel_cha
+@@ -1854,8 +1895,12 @@ STASIS_MESSAGE_TYPE_DEFN(ast_channel_cha
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_chanspy_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_fax_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_hangup_handler_type);
@@ -65,10 +65,10 @@ Index: asterisk-22.6.0/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_mute_type);
-Index: asterisk-22.6.0/rest-api/api-docs/events.json
+Index: asterisk-23.2.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-22.6.0.orig/rest-api/api-docs/events.json
-+++ asterisk-22.6.0/rest-api/api-docs/events.json
+--- asterisk-23.2.0.orig/rest-api/api-docs/events.json
++++ asterisk-23.2.0/rest-api/api-docs/events.json
 @@ -203,7 +203,9 @@
  				"ChannelConnectedLine",
  				"PeerStatusChange",
@@ -80,7 +80,7 @@ Index: asterisk-22.6.0/rest-api/api-docs/events.json
  			]
  		},
  		"ContactInfo": {
-@@ -1171,6 +1173,33 @@
+@@ -1179,6 +1181,33 @@
  					"description": "Response message body"
  				}
  			}
@@ -114,11 +114,11 @@ Index: asterisk-22.6.0/rest-api/api-docs/events.json
  		}
  	}
  }
-Index: asterisk-22.6.0/res/ari/ari_model_validators.c
+Index: asterisk-23.2.0/res/ari/ari_model_validators.c
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/ari_model_validators.c
-+++ asterisk-22.6.0/res/ari/ari_model_validators.c
-@@ -4826,6 +4826,212 @@ ari_validator ast_ari_validate_channel_l
+--- asterisk-23.2.0.orig/res/ari/ari_model_validators.c
++++ asterisk-23.2.0/res/ari/ari_model_validators.c
+@@ -4844,6 +4844,212 @@ ari_validator ast_ari_validate_channel_l
  	return ast_ari_validate_channel_left_bridge;
  }
  
@@ -331,7 +331,7 @@ Index: asterisk-22.6.0/res/ari/ari_model_validators.c
  int ast_ari_validate_channel_state_change(struct ast_json *json)
  {
  	int res = 1;
-@@ -6300,6 +6506,12 @@ int ast_ari_validate_event(struct ast_js
+@@ -6318,6 +6524,12 @@ int ast_ari_validate_event(struct ast_js
  	if (strcmp("ChannelLeftBridge", discriminator) == 0) {
  		return ast_ari_validate_channel_left_bridge(json);
  	} else
@@ -344,7 +344,7 @@ Index: asterisk-22.6.0/res/ari/ari_model_validators.c
  	if (strcmp("ChannelStateChange", discriminator) == 0) {
  		return ast_ari_validate_channel_state_change(json);
  	} else
-@@ -6522,6 +6734,12 @@ int ast_ari_validate_message(struct ast_
+@@ -6540,6 +6752,12 @@ int ast_ari_validate_message(struct ast_
  	if (strcmp("ChannelLeftBridge", discriminator) == 0) {
  		return ast_ari_validate_channel_left_bridge(json);
  	} else
@@ -357,10 +357,10 @@ Index: asterisk-22.6.0/res/ari/ari_model_validators.c
  	if (strcmp("ChannelStateChange", discriminator) == 0) {
  		return ast_ari_validate_channel_state_change(json);
  	} else
-Index: asterisk-22.6.0/res/ari/ari_model_validators.h
+Index: asterisk-23.2.0/res/ari/ari_model_validators.h
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/ari_model_validators.h
-+++ asterisk-22.6.0/res/ari/ari_model_validators.h
+--- asterisk-23.2.0.orig/res/ari/ari_model_validators.h
++++ asterisk-23.2.0/res/ari/ari_model_validators.h
 @@ -912,6 +912,38 @@ int ast_ari_validate_channel_left_bridge
  ari_validator ast_ari_validate_channel_left_bridge_fn(void);
  
@@ -400,7 +400,7 @@ Index: asterisk-22.6.0/res/ari/ari_model_validators.h
   * \brief Validator for ChannelStateChange.
   *
   * Notification of a channel's state change.
-@@ -1792,6 +1824,19 @@ ari_validator ast_ari_validate_applicati
+@@ -1794,6 +1826,19 @@ ari_validator ast_ari_validate_applicati
   * - timestamp: Date (required)
   * - bridge: Bridge (required)
   * - channel: Channel (required)

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/res/ari/resource_channels.c
+Index: asterisk-23.2.0/res/ari/resource_channels.c
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/resource_channels.c
-+++ asterisk-22.6.0/res/ari/resource_channels.c
+--- asterisk-23.2.0.orig/res/ari/resource_channels.c
++++ asterisk-23.2.0/res/ari/resource_channels.c
 @@ -1574,6 +1574,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-22.6.0/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-22.6.0/res/ari/resource_channels.h
+Index: asterisk-23.2.0/res/ari/resource_channels.h
 ===================================================================
---- asterisk-22.6.0.orig/res/ari/resource_channels.h
-+++ asterisk-22.6.0/res/ari/resource_channels.h
+--- asterisk-23.2.0.orig/res/ari/resource_channels.h
++++ asterisk-23.2.0/res/ari/resource_channels.h
 @@ -706,6 +706,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *variable;
  	/*! The value to set the variable to */
@@ -37,10 +37,10 @@ Index: asterisk-22.6.0/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-22.6.0/res/res_ari_channels.c
+Index: asterisk-23.2.0/res/res_ari_channels.c
 ===================================================================
---- asterisk-22.6.0.orig/res/res_ari_channels.c
-+++ asterisk-22.6.0/res/res_ari_channels.c
+--- asterisk-23.2.0.orig/res/res_ari_channels.c
++++ asterisk-23.2.0/res/res_ari_channels.c
 @@ -2484,6 +2484,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->value = ast_json_string_get(field);
@@ -62,10 +62,10 @@ Index: asterisk-22.6.0/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-22.6.0/rest-api/api-docs/channels.json
+Index: asterisk-23.2.0/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-22.6.0.orig/rest-api/api-docs/channels.json
-+++ asterisk-22.6.0/rest-api/api-docs/channels.json
+--- asterisk-23.2.0.orig/rest-api/api-docs/channels.json
++++ asterisk-23.2.0/rest-api/api-docs/channels.json
 @@ -1601,6 +1601,15 @@
  							"required": false,
  							"allowMultiple": false,

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/main/ccss.c
+Index: asterisk-23.2.0/main/ccss.c
 ===================================================================
---- asterisk-22.6.0.orig/main/ccss.c
-+++ asterisk-22.6.0/main/ccss.c
-@@ -2653,6 +2653,8 @@ struct cc_generic_agent_pvt {
+--- asterisk-23.2.0.orig/main/ccss.c
++++ asterisk-23.2.0/main/ccss.c
+@@ -2698,6 +2698,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {
  	struct cc_generic_agent_pvt *generic_pvt = ast_calloc(1, sizeof(*generic_pvt));
@@ -11,7 +11,7 @@ Index: asterisk-22.6.0/main/ccss.c
  
  	if (!generic_pvt) {
  		return -1;
-@@ -2665,8 +2667,18 @@ static int cc_generic_agent_init(struct
+@@ -2710,8 +2712,18 @@ static int cc_generic_agent_init(struct
  	if (ast_channel_caller(chan)->id.name.valid && ast_channel_caller(chan)->id.name.str) {
  		ast_copy_string(generic_pvt->cid_name, ast_channel_caller(chan)->id.name.str, sizeof(generic_pvt->cid_name));
  	}

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/include/asterisk/channel.h
+Index: asterisk-23.2.0/include/asterisk/channel.h
 ===================================================================
---- asterisk-22.6.0.orig/include/asterisk/channel.h
-+++ asterisk-22.6.0/include/asterisk/channel.h
-@@ -4475,6 +4475,18 @@ int ast_channel_dialed_causes_add(const
+--- asterisk-23.2.0.orig/include/asterisk/channel.h
++++ asterisk-23.2.0/include/asterisk/channel.h
+@@ -4495,6 +4495,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
  
@@ -21,11 +21,11 @@ Index: asterisk-22.6.0/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-22.6.0/main/channel.c
+Index: asterisk-23.2.0/main/channel.c
 ===================================================================
---- asterisk-22.6.0.orig/main/channel.c
-+++ asterisk-22.6.0/main/channel.c
-@@ -11045,3 +11045,34 @@ void ast_channel_clear_flag(struct ast_c
+--- asterisk-23.2.0.orig/main/channel.c
++++ asterisk-23.2.0/main/channel.c
+@@ -11086,3 +11086,34 @@ void ast_channel_clear_flag(struct ast_c
  	ast_channel_unlock(chan);
  }
  

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/main/features.c
+Index: asterisk-23.2.0/main/features.c
 ===================================================================
---- asterisk-22.6.0.orig/main/features.c
-+++ asterisk-22.6.0/main/features.c
+--- asterisk-23.2.0.orig/main/features.c
++++ asterisk-23.2.0/main/features.c
 @@ -644,6 +644,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-22.6.0/include/asterisk/file.h
+Index: asterisk-23.2.0/include/asterisk/file.h
 ===================================================================
---- asterisk-22.6.0.orig/include/asterisk/file.h
-+++ asterisk-22.6.0/include/asterisk/file.h
+--- asterisk-23.2.0.orig/include/asterisk/file.h
++++ asterisk-23.2.0/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,11 +10,11 @@ Index: asterisk-22.6.0/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-22.6.0/main/bridge_basic.c
+Index: asterisk-23.2.0/main/bridge_basic.c
 ===================================================================
---- asterisk-22.6.0.orig/main/bridge_basic.c
-+++ asterisk-22.6.0/main/bridge_basic.c
-@@ -3220,7 +3220,7 @@ static int grab_transfer(struct ast_chan
+--- asterisk-23.2.0.orig/main/bridge_basic.c
++++ asterisk-23.2.0/main/bridge_basic.c
+@@ -3222,7 +3222,7 @@ static int grab_transfer(struct ast_chan
  
  	/* Play the simple "transfer" prompt out and wait */
  	if (!ast_strlen_zero(announce_sound)) {

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,9 +1,9 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -10677,6 +10677,7 @@ static int manager_queues_summary(struct
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -10594,6 +10594,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;
  	int qmemcount = 0;
@@ -11,7 +11,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int qmemavail = 0;
  	int qchancount = 0;
  	int qlongestholdtime = 0;
-@@ -10708,6 +10709,7 @@ static int manager_queues_summary(struct
+@@ -10625,6 +10626,7 @@ static int manager_queues_summary(struct
  		if (ast_strlen_zero(queuefilter) || !strcasecmp(q->name, queuefilter)) {
  			/* Reset the necessary local variables if no queuefilter is set*/
  			qmemcount = 0;
@@ -19,7 +19,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			qmemavail = 0;
  			qchancount = 0;
  			qlongestholdtime = 0;
-@@ -10721,6 +10723,9 @@ static int manager_queues_summary(struct
+@@ -10638,6 +10640,9 @@ static int manager_queues_summary(struct
  						++qmemavail;
  					}
  				}
@@ -29,7 +29,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				ao2_ref(mem, -1);
  			}
  			ao2_iterator_destroy(&mem_iter);
-@@ -10734,13 +10739,14 @@ static int manager_queues_summary(struct
+@@ -10651,13 +10656,14 @@ static int manager_queues_summary(struct
  				"Queue: %s\r\n"
  				"LoggedIn: %d\r\n"
  				"Available: %d\r\n"

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -1875,6 +1875,7 @@ struct queue_ent {
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -1835,6 +1835,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
  	char digits[AST_MAX_EXTENSION];        /*!< Digits entered while in queue */
@@ -10,7 +10,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	const char *predial_callee;            /*!< Gosub app arguments for outgoing calls.  NULL if not supplied. */
  	int valid_digits;                      /*!< Digits entered correspond to valid extension. Exited */
  	int pos;                               /*!< Where we are in the queue */
-@@ -2424,6 +2425,20 @@ static struct ast_manager_event_blob *qu
+@@ -2384,6 +2385,20 @@ static struct ast_manager_event_blob *qu
  	RAII_VAR(struct ast_str *, event_string, NULL, ast_free);
  
  	channel_string = ast_manager_build_channel_state_string(obj->snapshot);
@@ -31,7 +31,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	event_string = ast_manager_str_from_json_object(obj->blob, NULL);
  	if (!channel_string || !event_string) {
  		return NULL;
-@@ -4789,10 +4804,11 @@ static void leave_queue(struct queue_ent
+@@ -4749,10 +4764,11 @@ static void leave_queue(struct queue_ent
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  			}
  
@@ -45,7 +45,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			ast_channel_publish_cached_blob(qe->chan, queue_caller_leave_type(), blob);
  			ast_debug(1, "Queue '%s' Leave, Channel '%s'\n", q->name, ast_channel_name(qe->chan));
  			/* Take us out of the queue */
-@@ -9100,6 +9116,8 @@ static int queue_exec(struct ast_channel
+@@ -9068,6 +9084,8 @@ static int queue_exec(struct ast_channel
  	} else {
  		raise_penalty = INT_MAX;
  	}

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -4697,7 +4697,7 @@ static int say_position(struct queue_ent
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -4657,7 +4657,7 @@ static int say_position(struct queue_ent
  		}
  
  		if (avgholdmins >= 1) {
@@ -11,7 +11,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			if (res) {
  				goto playout;
  			}
-@@ -4715,7 +4715,7 @@ static int say_position(struct queue_ent
+@@ -4675,7 +4675,7 @@ static int say_position(struct queue_ent
  			}
  		}
  		if (avgholdsecs >= 1) {

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -6882,10 +6882,10 @@ static void handle_blind_transfer(void *
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -6842,10 +6842,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
@@ -15,7 +15,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -6940,10 +6940,10 @@ static void handle_attended_transfer(voi
+@@ -6900,10 +6900,10 @@ static void handle_attended_transfer(voi
  	ast_debug(3, "Detected attended transfer in queue %s\n", queue_data->queue->name);
  	log_attended_transfer(queue_data, atxfer_msg);
  
@@ -28,7 +28,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -7138,10 +7138,10 @@ static void handle_hangup(void *userdata
+@@ -7106,10 +7106,10 @@ static void handle_hangup(void *userdata
  		(long) (queue_data->starttime - queue_data->holdstart),
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/main/channel.c
+Index: asterisk-23.2.0/main/channel.c
 ===================================================================
---- asterisk-22.6.0.orig/main/channel.c
-+++ asterisk-22.6.0/main/channel.c
-@@ -4868,7 +4868,24 @@ int ast_senddigit_begin(struct ast_chann
+--- asterisk-23.2.0.orig/main/channel.c
++++ asterisk-23.2.0/main/channel.c
+@@ -4897,7 +4897,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);
  

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,8 +1,8 @@
-Index: asterisk-22.6.0/apps/app_queue.c
+Index: asterisk-23.2.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.6.0.orig/apps/app_queue.c
-+++ asterisk-22.6.0/apps/app_queue.c
-@@ -1691,6 +1691,8 @@ enum queue_reload_mask {
+--- asterisk-23.2.0.orig/apps/app_queue.c
++++ asterisk-23.2.0/apps/app_queue.c
+@@ -1651,6 +1651,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
  	QUEUE_RESET_STATS = (1 << 3),
@@ -11,7 +11,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  };
  
  static const struct strategy {
-@@ -1861,9 +1863,14 @@ struct callattempt {
+@@ -1821,9 +1823,14 @@ struct callattempt {
  	char *orig_chan_name;
  };
  
@@ -26,7 +26,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	char moh[MAX_MUSICCLASS];              /*!< Name of musiconhold to be used */
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
-@@ -1886,8 +1893,11 @@ struct queue_ent {
+@@ -1846,8 +1853,11 @@ struct queue_ent {
  	int raise_respect_min;                 /*!< A switch raise_penalty should respect min_penalty not just max_penalty */
  	int linpos;                            /*!< If using linear strategy, what position are we at? */
  	int linwrapped;                        /*!< Is the linpos wrapped? */
@@ -38,7 +38,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int cancel_answered_elsewhere;         /*!< Whether we should force the CAE flag on this call (C) option*/
  	unsigned int withdraw:1;               /*!< Should this call exit the queue at its next iteration? Used for QueueWithdrawCaller */
  	char *withdraw_info;                   /*!< Optional info passed by the caller of QueueWithdrawCaller */
-@@ -1897,6 +1907,89 @@ struct queue_ent {
+@@ -1857,6 +1867,89 @@ struct queue_ent {
  	struct queue_ent *next;                /*!< The next queue entry */
  };
  
@@ -128,7 +128,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  struct member {
  	char interface[AST_CHANNEL_NAME];    /*!< Technology/Location to dial to reach this member*/
  	char state_exten[AST_MAX_EXTENSION]; /*!< Extension to get state from (if using hint) */
-@@ -1904,6 +1997,7 @@ struct member {
+@@ -1864,6 +1957,7 @@ struct member {
  	char state_interface[AST_CHANNEL_NAME]; /*!< Technology/Location from which to read devicestate changes */
  	int state_id;                        /*!< Extension state callback id (if using hint) */
  	char membername[80];                 /*!< Member name to use in queue logs */
@@ -136,7 +136,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int penalty;                         /*!< Are we a last resort? */
  	int calls;                           /*!< Number of calls serviced by this member */
  	int dynamic;                         /*!< Are we dynamically added? */
-@@ -1912,6 +2006,7 @@ struct member {
+@@ -1872,6 +1966,7 @@ struct member {
  	int paused;                          /*!< Are we paused (not accepting calls)? */
  	char reason_paused[80];              /*!< Reason of paused if member is paused */
  	int queuepos;                        /*!< In what order (pertains to certain strategies) should this member be called? */
@@ -144,7 +144,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int callcompletedinsl;               /*!< Whether the current call was completed within service level */
  	int wrapuptime;                      /*!< Wrapup Time */
  	time_t starttime;                    /*!< The time at which the member answered the current caller. */
-@@ -2059,6 +2154,7 @@ struct call_queue {
+@@ -2019,6 +2114,7 @@ struct call_queue {
  
  	int log_restricted_caller_id:1;     /*!< Whether log Restricted Caller ID */
  
@@ -152,7 +152,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	struct ao2_container *members;      /*!< Head of the list of members */
  	struct queue_ent *head;             /*!< Head of the list of callers */
  	AST_LIST_ENTRY(call_queue) list;    /*!< Next call queue */
-@@ -2081,6 +2177,40 @@ static int set_member_paused(const char
+@@ -2041,6 +2137,40 @@ static int set_member_paused(const char
  static int update_queue(struct call_queue *q, struct member *member, int callcompletedinsl, time_t starttime);
  
  static struct member *find_member_by_queuename_and_interface(const char *queuename, const char *interface);
@@ -193,7 +193,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  /*! \brief sets the QUEUESTATUS channel variable */
  static void set_queue_result(struct ast_channel *chan, enum queue_result res)
  {
-@@ -2569,7 +2699,7 @@ static void queue_publish_member_blob(st
+@@ -2529,7 +2659,7 @@ static void queue_publish_member_blob(st
  
  static struct ast_json *queue_member_blob_create(struct call_queue *q, struct member *mem)
  {
@@ -202,7 +202,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		"Queue", q->name,
  		"MemberName", mem->membername,
  		"Interface", mem->interface,
-@@ -2585,7 +2715,8 @@ static struct ast_json *queue_member_blo
+@@ -2545,7 +2675,8 @@ static struct ast_json *queue_member_blo
  		"Paused", mem->paused,
  		"PausedReason", mem->reason_paused,
  		"Ringinuse", mem->ringinuse,
@@ -212,7 +212,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  }
  
  /*! \brief Check if members are available
-@@ -2594,7 +2725,7 @@ static struct ast_json *queue_member_blo
+@@ -2554,7 +2685,7 @@ static struct ast_json *queue_member_blo
   * is available, the function immediately returns 0. If no members are available,
   * then -1 is returned.
   */
@@ -221,7 +221,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  {
  	struct member *member;
  	struct ao2_iterator mem_iter;
-@@ -2619,6 +2750,11 @@ static int get_member_status(struct call
+@@ -2579,6 +2710,11 @@ static int get_member_status(struct call
  			}
  		}
  
@@ -233,7 +233,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		switch (devstate ? ast_device_state(member->state_interface) : member->status) {
  		case AST_DEVICE_INVALID:
  			if (conditions & QUEUE_EMPTY_INVALID) {
-@@ -2677,7 +2813,7 @@ static int get_member_status(struct call
+@@ -2637,7 +2773,7 @@ static int get_member_status(struct call
  
  	if (!devstate && (conditions & QUEUE_EMPTY_RINGING)) {
  		/* member state still may be RINGING due to lag in event message - check again with device state */
@@ -242,7 +242,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	}
  	return -1;
  }
-@@ -2773,6 +2909,7 @@ static void update_status(struct call_qu
+@@ -2733,6 +2869,7 @@ static void update_status(struct call_qu
  		 */
  		pending_members_remove(m);
  
@@ -250,7 +250,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		queue_publish_member_blob(queue_member_status_type(), queue_member_blob_create(q, m));
  	}
  }
-@@ -2783,7 +2920,7 @@ static void update_status(struct call_qu
+@@ -2743,7 +2880,7 @@ static void update_status(struct call_qu
   * \retval 1 if the member is available
   * \retval 0 if the member is not available
   */
@@ -259,7 +259,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  {
  	int available = 0;
  	int wrapuptime;
-@@ -2803,7 +2940,8 @@ static int is_member_available(struct ca
+@@ -2763,7 +2900,8 @@ static int is_member_available(struct ca
  			/* else fall through */
  		case AST_DEVICE_NOT_INUSE:
  		case AST_DEVICE_UNKNOWN:
@@ -269,7 +269,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				available = 1;
  			}
  			break;
-@@ -2864,7 +3002,7 @@ static void device_state_cb(void *unused
+@@ -2824,7 +2962,7 @@ static void device_state_cb(void *unused
  
  			/* check every member until we find one NOT_INUSE */
  			if (!avail) {
@@ -278,7 +278,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			}
  			if (avail && found_member) {
  				/* early exit as we've found an available member and the member of interest */
-@@ -3042,7 +3180,7 @@ static void destroy_queue_member_cb(void
+@@ -3002,7 +3140,7 @@ static void destroy_queue_member_cb(void
  }
  
  /*! \brief allocate space for new queue member and set fields based on parameters passed */
@@ -287,7 +287,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  {
  	struct member *cur;
  
-@@ -3081,6 +3219,10 @@ static struct member *create_queue_membe
+@@ -3041,6 +3179,10 @@ static struct member *create_queue_membe
  			cur->state_id = -1;
  		}
  		cur->status = get_queue_member_status(cur);
@@ -298,7 +298,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	}
  
  	return cur;
-@@ -3789,6 +3931,7 @@ static void rt_handle_member_record(stru
+@@ -3749,6 +3891,7 @@ static void rt_handle_member_record(stru
  	const char *paused_str = ast_variable_retrieve(member_config, category, "paused");
  	const char *wrapuptime_str = ast_variable_retrieve(member_config, category, "wrapuptime");
  	const char *reason_paused = ast_variable_retrieve(member_config, category, "reason_paused");
@@ -306,7 +306,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  	if (ast_strlen_zero(rt_uniqueid)) {
  		ast_log(LOG_WARNING, "Realtime field 'uniqueid' is empty for member %s\n",
-@@ -3853,6 +3996,11 @@ static void rt_handle_member_record(stru
+@@ -3813,6 +3956,11 @@ static void rt_handle_member_record(stru
  				ast_copy_string(m->state_interface, state_interface, sizeof(m->state_interface));
  			}
  			m->penalty = penalty;
@@ -318,7 +318,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			m->ringinuse = ringinuse;
  			m->wrapuptime = wrapuptime;
  			if (realtime_reason_paused) {
-@@ -3860,6 +4008,7 @@ static void rt_handle_member_record(stru
+@@ -3820,6 +3968,7 @@ static void rt_handle_member_record(stru
  			}
  			found = 1;
  			ao2_ref(m, -1);
@@ -326,7 +326,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			break;
  		}
  		ao2_ref(m, -1);
-@@ -3868,9 +4017,10 @@ static void rt_handle_member_record(stru
+@@ -3828,9 +3977,10 @@ static void rt_handle_member_record(stru
  
  	/* Create a new member */
  	if (!found) {
@@ -338,7 +338,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			ast_copy_string(m->rt_uniqueid, rt_uniqueid, sizeof(m->rt_uniqueid));
  			if (!ast_strlen_zero(reason_paused)) {
  				ast_copy_string(m->reason_paused, reason_paused, sizeof(m->reason_paused));
-@@ -3917,6 +4067,10 @@ static void destroy_queue(void *obj)
+@@ -3877,6 +4027,10 @@ static void destroy_queue(void *obj)
  		}
  	}
  	ao2_ref(q->members, -1);
@@ -349,7 +349,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  }
  
  static struct call_queue *alloc_queue(const char *queuename)
-@@ -4251,6 +4405,34 @@ static void update_realtime_members(stru
+@@ -4211,6 +4365,34 @@ static void update_realtime_members(stru
  	ast_config_destroy(member_config);
  }
  
@@ -384,7 +384,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  static int join_queue(char *queuename, struct queue_ent *qe, enum queue_result *reason, int position)
  {
  	struct call_queue *q;
-@@ -4267,7 +4449,7 @@ static int join_queue(char *queuename, s
+@@ -4227,7 +4409,7 @@ static int join_queue(char *queuename, s
  	/* This is our one */
  	if (q->joinempty) {
  		int status = 0;
@@ -393,7 +393,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			*reason = QUEUE_JOINEMPTY;
  			ao2_unlock(q);
  			queue_t_unref(q, "Done with realtime queue");
-@@ -4284,6 +4466,10 @@ static int join_queue(char *queuename, s
+@@ -4244,6 +4426,10 @@ static int join_queue(char *queuename, s
  		 * Take into account the priority of the calling user */
  		inserted = 0;
  		prev = NULL;
@@ -404,7 +404,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		cur = q->head;
  		while (cur) {
  			/* We have higher priority than the current user, enter
-@@ -4316,6 +4502,7 @@ static int join_queue(char *queuename, s
+@@ -4276,6 +4462,7 @@ static int join_queue(char *queuename, s
  		ast_copy_string(qe->announce, q->announce, sizeof(qe->announce));
  		ast_copy_string(qe->context, q->context, sizeof(qe->context));
  		q->count++;
@@ -412,7 +412,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		if (q->count == 1) {
  			ast_devstate_changed(AST_DEVICE_RINGING, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  		}
-@@ -4401,7 +4588,7 @@ static int valid_exit(struct queue_ent *
+@@ -4361,7 +4548,7 @@ static int valid_exit(struct queue_ent *
  
  static int say_position(struct queue_ent *qe, int ringing)
  {
@@ -421,7 +421,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	long avgholdmins, avgholdsecs;
  	time_t now;
  
-@@ -4458,11 +4645,12 @@ static int say_position(struct queue_ent
+@@ -4418,11 +4605,12 @@ static int say_position(struct queue_ent
  		}
  	}
  	/* Round hold time to nearest minute */
@@ -436,7 +436,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		avgholdsecs *= qe->parent->roundingseconds;
  	} else {
  		avgholdsecs = 0;
-@@ -4583,6 +4771,8 @@ static void leave_queue(struct queue_ent
+@@ -4543,6 +4731,8 @@ static void leave_queue(struct queue_ent
  			RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
  			char posstr[20];
  			q->count--;
@@ -445,7 +445,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			if (!q->count) {
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  			}
-@@ -4699,9 +4889,10 @@ static void hangupcalls(struct queue_ent
+@@ -4659,9 +4849,10 @@ static void hangupcalls(struct queue_ent
   * \note The queue passed in should be locked prior to this function call
   *
   * \param[in] q The queue for which we are counting the number of available members
@@ -457,7 +457,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  {
  	struct member *mem;
  	int avl = 0;
-@@ -4710,7 +4901,7 @@ static int num_available_members(struct
+@@ -4670,7 +4861,7 @@ static int num_available_members(struct
  	mem_iter = ao2_iterator_init(q->members, 0);
  	while ((mem = ao2_iterator_next(&mem_iter))) {
  
@@ -466,7 +466,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		ao2_ref(mem, -1);
  
  		/* If autofill is not enabled or if the queue's strategy is ringall, then
-@@ -4751,7 +4942,7 @@ static int compare_weight(struct call_qu
+@@ -4711,7 +4902,7 @@ static int compare_weight(struct call_qu
  		if (q->count && q->members) {
  			if ((mem = ao2_find(q->members, member, OBJ_POINTER))) {
  				ast_debug(1, "Found matching member %s in queue '%s'\n", mem->interface, q->name);
@@ -475,7 +475,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  					ast_debug(1, "Queue '%s' (weight %d, calls %d) is preferred over '%s' (weight %d, calls %d)\n", q->name, q->weight, q->count, rq->name, rq->weight, rq->count);
  					found = 1;
  				}
-@@ -4849,7 +5040,7 @@ static int member_status_available(int s
+@@ -4809,7 +5000,7 @@ static int member_status_available(int s
   *
   * \retval non-zero if an entry can be called.
   */
@@ -484,7 +484,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  {
  	struct member *memberp = call->member;
  	int wrapuptime;
-@@ -4876,6 +5067,13 @@ static int can_ring_entry(struct queue_e
+@@ -4836,6 +5027,13 @@ static int can_ring_entry(struct queue_e
  		return 0;
  	}
  
@@ -498,7 +498,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	if (use_weight && compare_weight(qe->parent, memberp)) {
  		ast_debug(1, "Priority queue delaying call to %s:%s\n",
  			qe->parent->name, call->interface);
-@@ -4955,7 +5153,7 @@ static int ring_entry(struct queue_ent *
+@@ -4915,7 +5113,7 @@ static int ring_entry(struct queue_ent *
  	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
  
  	/* on entry here, we know that tmp->chan == NULL */
@@ -507,7 +507,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		tmp->stillgoing = 0;
  		++*busies;
  		return 0;
-@@ -5946,14 +6144,14 @@ static int is_our_turn(struct queue_ent
+@@ -5906,14 +6104,14 @@ static int is_our_turn(struct queue_ent
  	/* This needs a lock. How many members are available to be served? */
  	ao2_lock(qe->parent);
  
@@ -524,7 +524,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			idx++;
  		}
  		ch = ch->next;
-@@ -6103,7 +6301,7 @@ static int wait_our_turn(struct queue_en
+@@ -6063,7 +6261,7 @@ static int wait_our_turn(struct queue_en
  		if (qe->parent->leavewhenempty) {
  			int status = 0;
  
@@ -533,7 +533,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				record_abandoned(qe);
  				*reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(qe->parent->name, ast_channel_uniqueid(qe->chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe->pos, qe->opos, (long) (time(NULL) - qe->start));
-@@ -6155,6 +6353,13 @@ static int wait_our_turn(struct queue_en
+@@ -6115,6 +6313,13 @@ static int wait_our_turn(struct queue_en
  			*reason = QUEUE_TIMEOUT;
  			break;
  		}
@@ -547,7 +547,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	}
  
  	return res;
-@@ -7388,6 +7593,7 @@ static int try_calling(struct queue_ent
+@@ -7356,6 +7561,7 @@ static int try_calling(struct queue_ent
  		ao2_unlock(qe->parent);
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
@@ -555,7 +555,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		hangupcalls(qe, outgoing, peer, qe->cancel_answered_elsewhere);
  		outgoing = NULL;
  		if (announce || qe->parent->reportholdtime || qe->parent->memberdelay) {
-@@ -7674,7 +7880,7 @@ static struct member *interface_exists(s
+@@ -7642,7 +7848,7 @@ static struct member *interface_exists(s
  
  /*! \brief Dump all members in a specific queue to the database
   * \code
@@ -564,7 +564,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
   * \endcode
   */
  static void dump_queue_members(struct call_queue *pm_queue)
-@@ -7700,13 +7906,14 @@ static void dump_queue_members(struct ca
+@@ -7668,13 +7874,14 @@ static void dump_queue_members(struct ca
  			continue;
  		}
  
@@ -580,7 +580,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			cur_member->reason_paused,
  			cur_member->wrapuptime);
  
-@@ -7738,6 +7945,7 @@ static int remove_from_queue(const char
+@@ -7706,6 +7913,7 @@ static int remove_from_queue(const char
  		.name = queuename,
  	};
  	struct member *mem, tmpmem;
@@ -588,7 +588,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int res = RES_NOSUCHQUEUE;
  
  	ast_copy_string(tmpmem.interface, interface, sizeof(tmpmem.interface));
-@@ -7757,13 +7965,20 @@ static int remove_from_queue(const char
+@@ -7725,13 +7933,20 @@ static int remove_from_queue(const char
  			queue_publish_member_blob(queue_member_removed_type(), queue_member_blob_create(q, mem));
  
  			member_remove_from_queue(q, mem);
@@ -610,7 +610,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -7785,7 +8000,7 @@ static int remove_from_queue(const char
+@@ -7753,7 +7968,7 @@ static int remove_from_queue(const char
   * \retval RES_EXISTS queue exists but no members
   * \retval RES_OUT_OF_MEMORY queue exists but not enough memory to create member
  */
@@ -619,7 +619,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  {
  	struct call_queue *q;
  	struct member *new_member, *old_member;
-@@ -7799,15 +8014,16 @@ static int add_to_queue(const char *queu
+@@ -7767,15 +7982,16 @@ static int add_to_queue(const char *queu
  
  	ao2_lock(q);
  	if ((old_member = interface_exists(q, interface)) == NULL) {
@@ -638,7 +638,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -8023,10 +8239,10 @@ static void set_queue_member_pause(struc
+@@ -7991,10 +8207,10 @@ static void set_queue_member_pause(struc
  		dump_queue_members(q);
  	}
  
@@ -651,7 +651,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		ast_devstate_changed(AST_DEVICE_INUSE, AST_DEVSTATE_CACHABLE,
  			"Queue:%s_avail", q->name);
  	}
-@@ -8041,6 +8257,7 @@ static void set_queue_member_pause(struc
+@@ -8009,6 +8225,7 @@ static void set_queue_member_pause(struc
  
  	ast_queue_log(q->name, "NONE", mem->membername, paused ? "PAUSE" : "UNPAUSE",
  		"%s", mem->reason_paused);
@@ -659,7 +659,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  	publish_queue_member_pause(q, mem);
  
-@@ -8304,6 +8521,7 @@ static void reload_queue_members(void)
+@@ -8272,6 +8489,7 @@ static void reload_queue_members(void)
  	char *member;
  	char *interface;
  	char *membername = NULL;
@@ -667,7 +667,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	char *state_interface;
  	char *penalty_tok;
  	int penalty = 0;
-@@ -8358,6 +8576,7 @@ static void reload_queue_members(void)
+@@ -8326,6 +8544,7 @@ static void reload_queue_members(void)
  			paused_tok = strsep(&member, ";");
  			membername = strsep(&member, ";");
  			state_interface = strsep(&member, ";");
@@ -675,7 +675,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			reason_paused = strsep(&member, ";");
  			wrapuptime_tok = strsep(&member, ";");
  
-@@ -8392,7 +8611,7 @@ static void reload_queue_members(void)
+@@ -8360,7 +8579,7 @@ static void reload_queue_members(void)
  			ast_debug(1, "Reload Members: Queue: %s  Member: %s  Name: %s  Penalty: %d  Paused: %d ReasonPause: %s  Wrapuptime: %d\n",
  			              queue_name, interface, membername, penalty, paused, reason_paused, wrapuptime);
  
@@ -684,7 +684,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				ast_log(LOG_ERROR, "Out of Memory when reloading persistent queue member\n");
  				break;
  			}
-@@ -8563,6 +8782,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8531,6 +8750,7 @@ static int aqm_exec(struct ast_channel *
  		AST_APP_ARG(membername);
  		AST_APP_ARG(state_interface);
  		AST_APP_ARG(wrapuptime);
@@ -692,7 +692,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	);
  	int penalty = 0;
  	int paused = 0;
-@@ -8570,7 +8790,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8538,7 +8758,7 @@ static int aqm_exec(struct ast_channel *
  	struct ast_flags flags = { 0 };
  
  	if (ast_strlen_zero(data)) {
@@ -701,7 +701,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8615,7 +8835,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8583,7 +8803,7 @@ static int aqm_exec(struct ast_channel *
  		wrapuptime = 0;
  	}
  
@@ -710,7 +710,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(args.membername) || !log_membername_as_agent) {
  			ast_queue_log(args.queuename, ast_channel_uniqueid(chan), args.interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -8750,6 +8970,7 @@ static int queue_exec(struct ast_channel
+@@ -8718,6 +8938,7 @@ static int queue_exec(struct ast_channel
  		AST_APP_ARG(gosub);
  		AST_APP_ARG(rule);
  		AST_APP_ARG(position);
@@ -718,7 +718,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	);
  	/* Our queue entry */
  	struct queue_ent qe = { 0 };
-@@ -8759,7 +8980,7 @@ static int queue_exec(struct ast_channel
+@@ -8727,7 +8948,7 @@ static int queue_exec(struct ast_channel
  	int cid_allow;
  
  	if (ast_strlen_zero(data)) {
@@ -727,7 +727,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8891,6 +9112,9 @@ static int queue_exec(struct ast_channel
+@@ -8859,6 +9080,9 @@ static int queue_exec(struct ast_channel
  	qe.max_penalty = max_penalty;
  	qe.min_penalty = min_penalty;
  	qe.raise_penalty = raise_penalty;
@@ -737,7 +737,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	qe.last_pos_said = 0;
  	qe.last_pos = 0;
  	qe.last_periodic_announce_time = time(NULL);
-@@ -8966,6 +9190,18 @@ check_turns:
+@@ -8934,6 +9158,18 @@ check_turns:
  		ast_moh_start(chan, qe.moh, NULL);
  	}
  
@@ -756,7 +756,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	/* This is the wait loop for callers 2 through maxlen */
  	res = wait_our_turn(&qe, ringing, &reason);
  	if (res) {
-@@ -9044,7 +9280,7 @@ check_turns:
+@@ -9011,7 +9247,7 @@ check_turns:
  
  		if (qe.parent->leavewhenempty) {
  			int status = 0;
@@ -765,7 +765,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  				record_abandoned(&qe);
  				reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(args.queuename, ast_channel_uniqueid(chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe.pos, qe.opos, (long)(time(NULL) - qe.start));
-@@ -9146,6 +9382,16 @@ stop:
+@@ -9113,6 +9349,16 @@ stop:
  	if (reason != QUEUE_UNKNOWN)
  		set_queue_result(chan, reason);
  
@@ -782,7 +782,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	/*
  	 * every queue_ent is given a reference to it's parent
  	 * call_queue when it joins the queue.  This ref must be taken
-@@ -9820,6 +10066,7 @@ static void queue_reset_global_params(vo
+@@ -9737,6 +9983,7 @@ static void queue_reset_global_params(vo
  	log_unpause_on_reason_change = 0;
  }
  
@@ -790,7 +790,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  /*! Set the global queue parameters as defined in the "general" section of queues.conf */
  static void queue_set_global_params(struct ast_config *cfg)
  {
-@@ -9865,7 +10112,7 @@ static void queue_set_global_params(stru
+@@ -9782,7 +10029,7 @@ static void queue_set_global_params(stru
   */
  static void reload_single_member(const char *memberdata, struct call_queue *q)
  {
@@ -799,7 +799,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	char *parse;
  	struct member *cur, *newm;
  	struct member tmpmem;
-@@ -9881,6 +10128,7 @@ static void reload_single_member(const c
+@@ -9798,6 +10045,7 @@ static void reload_single_member(const c
  		AST_APP_ARG(ringinuse);
  		AST_APP_ARG(wrapuptime);
  		AST_APP_ARG(paused);
@@ -807,7 +807,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	);
  
  	if (ast_strlen_zero(memberdata)) {
-@@ -9935,6 +10183,10 @@ static void reload_single_member(const c
+@@ -9852,6 +10100,10 @@ static void reload_single_member(const c
  		ringinuse = q->ringinuse;
  	}
  
@@ -818,7 +818,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	if (!ast_strlen_zero(args.wrapuptime)) {
  		tmp = args.wrapuptime;
  		ast_strip(tmp);
-@@ -9969,7 +10221,7 @@ static void reload_single_member(const c
+@@ -9886,7 +10138,7 @@ static void reload_single_member(const c
  		paused = cur->paused;
  	}
  
@@ -827,7 +827,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		newm->wrapuptime = wrapuptime;
  		if (cur) {
  			ao2_lock(q->members);
-@@ -9989,6 +10241,7 @@ static void reload_single_member(const c
+@@ -9906,6 +10158,7 @@ static void reload_single_member(const c
  		ao2_ref(newm, -1);
  	}
  	newm = NULL;
@@ -835,7 +835,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  	if (cur) {
  		ao2_ref(cur, -1);
-@@ -10277,6 +10530,12 @@ static int reload_handler(int reload, st
+@@ -10194,6 +10447,12 @@ static int reload_handler(int reload, st
  	if (ast_test_flag(mask, QUEUE_RELOAD_RULES)) {
  		res |= reload_queue_rules(reload);
  	}
@@ -848,7 +848,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	if (ast_test_flag(mask, QUEUE_RESET_STATS)) {
  		res |= clear_stats(queuename);
  	}
-@@ -10365,6 +10624,8 @@ static void print_queue(struct mansessio
+@@ -10282,6 +10541,8 @@ static void print_queue(struct mansessio
  					mem->status == AST_DEVICE_UNAVAILABLE || mem->status == AST_DEVICE_UNKNOWN ?
  						COLOR_RED : COLOR_GREEN, COLOR_BLACK),
  					ast_devstate2str(mem->status), ast_term_reset());
@@ -857,7 +857,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			if (mem->calls) {
  				ast_str_append(&out, 0, " has taken %d calls (last was %ld secs ago)",
  					mem->calls, (long) (now - mem->lastcall));
-@@ -10386,8 +10647,32 @@ static void print_queue(struct mansessio
+@@ -10303,8 +10564,32 @@ static void print_queue(struct mansessio
  		struct queue_ent *qe;
  		int pos = 1;
  
@@ -890,7 +890,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  			ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
  				pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
  				(long) (now - qe->start) % 60, qe->prio);
-@@ -10837,11 +11122,12 @@ static int manager_queues_status(struct
+@@ -10754,11 +11039,12 @@ static int manager_queues_status(struct
  						"Paused: %d\r\n"
  						"PausedReason: %s\r\n"
  						"Wrapuptime: %d\r\n"
@@ -904,7 +904,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  					++q_items;
  				}
  				ao2_ref(mem, -1);
-@@ -10886,7 +11172,7 @@ static int manager_queues_status(struct
+@@ -10803,7 +11089,7 @@ static int manager_queues_status(struct
  
  static int manager_add_queue_member(struct mansession *s, const struct message *m)
  {
@@ -913,7 +913,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int paused, penalty, wrapuptime = 0;
  
  	queuename = astman_get_header(m, "Queue");
-@@ -10897,6 +11183,7 @@ static int manager_add_queue_member(stru
+@@ -10814,6 +11100,7 @@ static int manager_add_queue_member(stru
  	membername = astman_get_header(m, "MemberName");
  	state_interface = astman_get_header(m, "StateInterface");
  	wrapuptime_s = astman_get_header(m, "Wrapuptime");
@@ -921,7 +921,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  
  	if (ast_strlen_zero(queuename)) {
  		astman_send_error(s, m, "'Queue' not specified.");
-@@ -10926,7 +11213,7 @@ static int manager_add_queue_member(stru
+@@ -10843,7 +11130,7 @@ static int manager_add_queue_member(stru
  		paused = abs(ast_true(paused_s));
  	}
  
@@ -930,7 +930,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "MANAGER", interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -11057,6 +11344,14 @@ static int manager_queue_reload(struct m
+@@ -10974,6 +11261,14 @@ static int manager_queue_reload(struct m
  		ast_set_flag(&mask, QUEUE_RELOAD_RULES);
  		header_found = 1;
  	}
@@ -945,7 +945,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	if (!strcasecmp(S_OR(astman_get_header(m, "Parameters"), ""), "yes")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
  		header_found = 1;
-@@ -11266,7 +11561,7 @@ static int manager_request_withdraw_call
+@@ -11183,7 +11478,7 @@ static int manager_request_withdraw_call
  
  static char *handle_queue_add_member(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
  {
@@ -954,7 +954,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	int penalty, paused = 0;
  
  	switch ( cmd ) {
-@@ -11280,7 +11575,7 @@ static char *handle_queue_add_member(str
+@@ -11197,7 +11492,7 @@ static char *handle_queue_add_member(str
  		return complete_queue_add_member(a->line, a->word, a->pos, a->n);
  	}
  
@@ -963,7 +963,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  		return CLI_SHOWUSAGE;
  	} else if (strcmp(a->argv[4], "to")) {
  		return CLI_SHOWUSAGE;
-@@ -11292,6 +11587,8 @@ static char *handle_queue_add_member(str
+@@ -11209,6 +11504,8 @@ static char *handle_queue_add_member(str
  		return CLI_SHOWUSAGE;
  	} else if ((a->argc == 14) && strcmp(a->argv[12], "paused")) {
  		return CLI_SHOWUSAGE;
@@ -972,7 +972,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	}
  
  	queuename = a->argv[5];
-@@ -11323,7 +11620,11 @@ static char *handle_queue_add_member(str
+@@ -11240,7 +11537,11 @@ static char *handle_queue_add_member(str
  		reason = a->argv[13];
  	}
  
@@ -985,7 +985,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "CLI", interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -11853,6 +12154,10 @@ static char *handle_queue_reload(struct
+@@ -11770,6 +12071,10 @@ static char *handle_queue_reload(struct
  		ast_set_flag(&mask, QUEUE_RELOAD_MEMBER);
  	} else if (!strcasecmp(a->argv[2], "parameters")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
@@ -996,7 +996,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  	} else if (!strcasecmp(a->argv[2], "all")) {
  		ast_set_flag(&mask, AST_FLAGS_ALL & ~QUEUE_RESET_STATS);
  	}
-@@ -11949,6 +12254,1182 @@ static int qupd_exec(struct ast_channel
+@@ -11866,6 +12171,1182 @@ static int qupd_exec(struct ast_channel
  	return 0;
  }
  
@@ -2179,7 +2179,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  static struct ast_cli_entry cli_queue[] = {
  	AST_CLI_DEFINE(queue_show, "Show status of a specified queue"),
  	AST_CLI_DEFINE(handle_queue_rule_show, "Show the rules defined in queuerules.conf"),
-@@ -11960,11 +13441,10 @@ static struct ast_cli_entry cli_queue[]
+@@ -11877,11 +13358,10 @@ static struct ast_cli_entry cli_queue[]
  	AST_CLI_DEFINE(handle_queue_reload, "Reload queues, members, queue rules, or parameters"),
  	AST_CLI_DEFINE(handle_queue_reset, "Reset statistics for a queue"),
  	AST_CLI_DEFINE(handle_queue_change_priority_caller, "Change priority caller on queue"),
@@ -2193,7 +2193,7 @@ Index: asterisk-22.6.0/apps/app_queue.c
  static int unload_module(void)
  {
  	stasis_message_router_unsubscribe_and_join(agent_router);
-@@ -12196,32 +13676,6 @@ static int load_module(void)
+@@ -12111,32 +13591,6 @@ static int load_module(void)
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -2226,10 +2226,10 @@ Index: asterisk-22.6.0/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-22.6.0/configs/samples/queueskillrules.conf.sample
+Index: asterisk-23.2.0/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-22.6.0/configs/samples/queueskillrules.conf.sample
++++ asterisk-23.2.0/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2294,10 +2294,10 @@ Index: asterisk-22.6.0/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-22.6.0/configs/samples/queueskills.conf.sample
+Index: asterisk-23.2.0/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-22.6.0/configs/samples/queueskills.conf.sample
++++ asterisk-23.2.0/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
- **asterisk-23.2.0: update changelog**
- **asterisk-23.2.0: update patches**

**Note**
* Asterisk deprecated `VALID_EXTEN` in favour of `DIALPLAN_EXIST`
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades Debian packaging to Asterisk 23.2.0 and re-applies/refreshes Wazo patches with targeted fixes.
> 
> - **Security**: `astgenkey` now generates private keys with `umask 0077` and root-owned chown to `asterisk:`
> - **Build/packaging**: Avoid deleting sounds on `distclean`; add `all-clean` target
> - **Queues**: Expose `ast_queues_get_container()` (exported symbol) and mark module with `AST_MODFLAG_GLOBAL_SYMBOLS`
> - **Playback robustness**: Fail fast on invalid recording/number/URI in `res_stasis_playback` instead of continuing
> - **MOH resilience**: Add debug logs, abort after exhausting files, unlink bad classes, and warn on frame read failures
> - **Changelog**: Add entry for `8:23.2.0-1~wazo`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0242cc15e1d1bfd8f68f0e4af8cbd43a145267f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->