### PR TITLE
Fix deadlock in PJSIP channel creation with endpoint variables

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.8.1-1~wazo2) wazo-dev-bookworm; urgency=medium
+
+  * Fix deadlock in chan_pjsip_new when PJSIP_HEADER used as endpoint channel var
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 05 Mar 2026 10:00:00 -0500
+
 asterisk (8:22.8.1-1~wazo1) wazo-dev-bookworm; urgency=medium
 
   * asterisk 22.8.1

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -1,17 +1,18 @@
+# Set endpoint channel variables after unlock to prevent deadlock
+# when variables invoke dialplan functions (e.g., PJSIP_HEADER)
+# that block on serializer tasks while the channel lock is held.
+# pbx_builtin_setvar_helper will acquire and release channel lock on each invocation in the loop
 Index: asterisk-22.8.1/channels/chan_pjsip.c
 ===================================================================
 --- asterisk-22.8.1.orig/channels/chan_pjsip.c	2026-03-05 15:42:57.508015668 +0000
 +++ asterisk-22.8.1/channels/chan_pjsip.c	2026-03-05 15:43:19.673013563 +0000
-@@ -665,15 +665,18 @@
+@@ -665,15 +665,15 @@
  		ast_channel_zone_set(chan, zone);
  	}
  
 +	ast_channel_stage_snapshot_done(chan);
 +	ast_channel_unlock(chan);
 +
-+	/* Set endpoint channel variables after unlock to prevent deadlock
-+	 * when variables invoke dialplan functions (e.g., PJSIP_HEADER)
-+	 * that block on serializer tasks while the channel lock is held. */
  	for (var = session->endpoint->channel_vars; var; var = var->next) {
  		char buf[512];
  		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -1,0 +1,29 @@
+Index: asterisk-22.8.1/channels/chan_pjsip.c
+===================================================================
+--- asterisk-22.8.1.orig/channels/chan_pjsip.c
++++ asterisk-22.8.1/channels/chan_pjsip.c
+@@ -665,15 +665,17 @@
+ 		ast_channel_zone_set(chan, zone);
+ 	}
+
+-	for (var = session->endpoint->channel_vars; var; var = var->next) {
+-		char buf[512];
+-		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
+-					var->value, buf, sizeof(buf)));
+-	}
+-
+ 	ast_channel_stage_snapshot_done(chan);
+ 	ast_channel_unlock(chan);
+
++	/* Set endpoint channel variables after unlock to prevent deadlock
++	 * when variables invoke dialplan functions (e.g., PJSIP_HEADER)
++	 * that block on serializer tasks while the channel lock is held. */
++	for (var = session->endpoint->channel_vars; var; var = var->next) {
++		char buf[512];
++		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
++					var->value, buf, sizeof(buf)));
++	}
++
+ 	set_channel_on_rtp_instance(session, ast_channel_uniqueid(chan));
+
+ 	SCOPE_EXIT_RTN_VALUE(chan);

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -1,29 +1,26 @@
 Index: asterisk-22.8.1/channels/chan_pjsip.c
 ===================================================================
---- asterisk-22.8.1.orig/channels/chan_pjsip.c
-+++ asterisk-22.8.1/channels/chan_pjsip.c
-@@ -665,15 +665,17 @@
+--- asterisk-22.8.1.orig/channels/chan_pjsip.c	2026-03-05 15:42:57.508015668 +0000
++++ asterisk-22.8.1/channels/chan_pjsip.c	2026-03-05 15:43:19.673013563 +0000
+@@ -665,15 +665,18 @@
  		ast_channel_zone_set(chan, zone);
  	}
-
--	for (var = session->endpoint->channel_vars; var; var = var->next) {
--		char buf[512];
--		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
--					var->value, buf, sizeof(buf)));
--	}
--
- 	ast_channel_stage_snapshot_done(chan);
- 	ast_channel_unlock(chan);
-
+ 
++	ast_channel_stage_snapshot_done(chan);
++	ast_channel_unlock(chan);
++
 +	/* Set endpoint channel variables after unlock to prevent deadlock
 +	 * when variables invoke dialplan functions (e.g., PJSIP_HEADER)
 +	 * that block on serializer tasks while the channel lock is held. */
-+	for (var = session->endpoint->channel_vars; var; var = var->next) {
-+		char buf[512];
-+		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
-+					var->value, buf, sizeof(buf)));
-+	}
-+
+ 	for (var = session->endpoint->channel_vars; var; var = var->next) {
+ 		char buf[512];
+ 		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
+ 					var->value, buf, sizeof(buf)));
+ 	}
+ 
+-	ast_channel_stage_snapshot_done(chan);
+-	ast_channel_unlock(chan);
+-
  	set_channel_on_rtp_instance(session, ast_channel_uniqueid(chan));
-
+ 
  	SCOPE_EXIT_RTN_VALUE(chan);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,3 +29,4 @@ mix_monitor_announce_file
 fix-application-playback-update
 expose-app-queues-mutex
 fix-queue-deadlock
+fix-pjsip-channel-creation-deadlock


### PR DESCRIPTION
## Summary
This patch fixes a deadlock that occurs during PJSIP channel creation when endpoint channel variables are set while the channel lock is held.

## Key Changes
- Moved the endpoint channel variable assignment to occur **after** the channel is unlocked in `chan_pjsip.c`
- The variables are now set after `ast_channel_unlock(chan)` instead of before, preventing deadlock scenarios

## Implementation Details
The deadlock occurred because setting endpoint channel variables can trigger dialplan functions (such as `PJSIP_HEADER`) that may block on serializer tasks. When these operations occur while the channel lock is held, it creates a deadlock condition.

By deferring the variable assignment until after the channel is unlocked, the channel lock is no longer held when these potentially-blocking operations execute, eliminating the deadlock while maintaining the same functional behavior.

https://claude.ai/code/session_017gxrJFgjWNAVm25sYc76DP