### PR TITLE
DO NOT MERGE: add sleep to force race condition

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.8.1-1~wazo2) wazo-dev-bookworm; urgency=medium
+
+  * debug
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 26 Mar 2026 14:23:13 -0400
+
 asterisk (8:22.8.1-1~wazo1) wazo-dev-bookworm; urgency=medium
 
   * asterisk 22.8.1

--- a/debian/patches/debug-bridge-move-swap-usleep
+++ b/debian/patches/debug-bridge-move-swap-usleep
@@ -1,0 +1,14 @@
+Index: asterisk-22.8.1/main/bridge.c
+===================================================================
+--- asterisk-22.8.1.orig/main/bridge.c
++++ asterisk-22.8.1/main/bridge.c
+@@ -2888,6 +2888,9 @@ static int try_swap_optimize_out(struct
+ 			ast_channel_name(dst_bridge_channel->chan),
+ 			ast_channel_name(other->chan));
+ 
++		/* DEBUG: force race condition with CEL emission - remove before release */
++		usleep(50000); /* 50ms */
++
+ 		if (pvt && !ast_test_flag(pvt, AST_UNREAL_OPTIMIZE_BEGUN) && pvt->callbacks
+ 				&& pvt->callbacks->optimization_started) {
+ 			pvt->callbacks->optimization_started(pvt, other->chan,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,3 +29,4 @@ mix_monitor_announce_file
 fix-application-playback-update
 expose-app-queues-mutex
 fix-queue-deadlock
+debug-bridge-move-swap-usleep


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces an explicit 50ms `usleep` in core bridging (`try_swap_optimize_out`), which can change call timing/latency and intentionally provoke race conditions in production if shipped.
> 
> **Overview**
> Adds a Debian patch that injects a 50ms `usleep` in `main/bridge.c` during `try_swap_optimize_out` to deliberately force a race with CEL emission (explicitly marked *DEBUG* / *remove before release*).
> 
> Updates `debian/patches/series` to apply this new debug patch in the build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64b9c06813deeb4c24bd77226d61225cc4cef543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->