### PR TITLE
[ITEM-229] channel creation deadlock patch (based on asterisk 22.8.2)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.8.2-2~wazo1) wazo-dev-bookworm; urgency=medium
+
+  * Add channel creation deadlock patch
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 01 Apr 2026 09:09:25 -0400
+
 asterisk (8:22.8.2-1~wazo1) wazo-dev-bookworm; urgency=medium
 
   * asterisk 22.8.2

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -1,17 +1,18 @@
+# Set endpoint channel variables after unlock to prevent deadlock
+# when variables invoke dialplan functions (e.g., PJSIP_HEADER)
+# that block on serializer tasks while the channel lock is held.
+# pbx_builtin_setvar_helper will acquire and release channel lock on each invocation in the loop
 Index: asterisk-22.8.1/channels/chan_pjsip.c
 ===================================================================
 --- asterisk-22.8.1.orig/channels/chan_pjsip.c	2026-03-05 15:42:57.508015668 +0000
 +++ asterisk-22.8.1/channels/chan_pjsip.c	2026-03-05 15:43:19.673013563 +0000
-@@ -665,15 +665,18 @@
+@@ -665,15 +665,15 @@
  		ast_channel_zone_set(chan, zone);
  	}
  
 +	ast_channel_stage_snapshot_done(chan);
 +	ast_channel_unlock(chan);
 +
-+	/* Set endpoint channel variables after unlock to prevent deadlock
-+	 * when variables invoke dialplan functions (e.g., PJSIP_HEADER)
-+	 * that block on serializer tasks while the channel lock is held. */
  	for (var = session->endpoint->channel_vars; var; var = var->next) {
  		char buf[512];
  		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -1,0 +1,29 @@
+Index: asterisk-22.8.1/channels/chan_pjsip.c
+===================================================================
+--- asterisk-22.8.1.orig/channels/chan_pjsip.c
++++ asterisk-22.8.1/channels/chan_pjsip.c
+@@ -665,15 +665,17 @@
+ 		ast_channel_zone_set(chan, zone);
+ 	}
+
+-	for (var = session->endpoint->channel_vars; var; var = var->next) {
+-		char buf[512];
+-		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
+-					var->value, buf, sizeof(buf)));
+-	}
+-
+ 	ast_channel_stage_snapshot_done(chan);
+ 	ast_channel_unlock(chan);
+
++	/* Set endpoint channel variables after unlock to prevent deadlock
++	 * when variables invoke dialplan functions (e.g., PJSIP_HEADER)
++	 * that block on serializer tasks while the channel lock is held. */
++	for (var = session->endpoint->channel_vars; var; var = var->next) {
++		char buf[512];
++		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
++					var->value, buf, sizeof(buf)));
++	}
++
+ 	set_channel_on_rtp_instance(session, ast_channel_uniqueid(chan));
+
+ 	SCOPE_EXIT_RTN_VALUE(chan);

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -2,11 +2,11 @@
 # when variables invoke dialplan functions (e.g., PJSIP_HEADER)
 # that block on serializer tasks while the channel lock is held.
 # pbx_builtin_setvar_helper will acquire and release channel lock on each invocation in the loop
-Index: asterisk-22.8.1/channels/chan_pjsip.c
+Index: asterisk-22.8.2/channels/chan_pjsip.c
 ===================================================================
---- asterisk-22.8.1.orig/channels/chan_pjsip.c	2026-03-05 15:42:57.508015668 +0000
-+++ asterisk-22.8.1/channels/chan_pjsip.c	2026-03-05 15:43:19.673013563 +0000
-@@ -665,15 +665,15 @@
+--- asterisk-22.8.2.orig/channels/chan_pjsip.c
++++ asterisk-22.8.2/channels/chan_pjsip.c
+@@ -665,15 +665,15 @@ static struct ast_channel *chan_pjsip_ne
  		ast_channel_zone_set(chan, zone);
  	}
  

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -1,29 +1,26 @@
 Index: asterisk-22.8.1/channels/chan_pjsip.c
 ===================================================================
---- asterisk-22.8.1.orig/channels/chan_pjsip.c
-+++ asterisk-22.8.1/channels/chan_pjsip.c
-@@ -665,15 +665,17 @@
+--- asterisk-22.8.1.orig/channels/chan_pjsip.c	2026-03-05 15:42:57.508015668 +0000
++++ asterisk-22.8.1/channels/chan_pjsip.c	2026-03-05 15:43:19.673013563 +0000
+@@ -665,15 +665,18 @@
  		ast_channel_zone_set(chan, zone);
  	}
-
--	for (var = session->endpoint->channel_vars; var; var = var->next) {
--		char buf[512];
--		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
--					var->value, buf, sizeof(buf)));
--	}
--
- 	ast_channel_stage_snapshot_done(chan);
- 	ast_channel_unlock(chan);
-
+ 
++	ast_channel_stage_snapshot_done(chan);
++	ast_channel_unlock(chan);
++
 +	/* Set endpoint channel variables after unlock to prevent deadlock
 +	 * when variables invoke dialplan functions (e.g., PJSIP_HEADER)
 +	 * that block on serializer tasks while the channel lock is held. */
-+	for (var = session->endpoint->channel_vars; var; var = var->next) {
-+		char buf[512];
-+		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
-+					var->value, buf, sizeof(buf)));
-+	}
-+
+ 	for (var = session->endpoint->channel_vars; var; var = var->next) {
+ 		char buf[512];
+ 		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
+ 					var->value, buf, sizeof(buf)));
+ 	}
+ 
+-	ast_channel_stage_snapshot_done(chan);
+-	ast_channel_unlock(chan);
+-
  	set_channel_on_rtp_instance(session, ast_channel_uniqueid(chan));
-
+ 
  	SCOPE_EXIT_RTN_VALUE(chan);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,3 +29,4 @@ mix_monitor_announce_file
 fix-application-playback-update
 expose-app-queues-mutex
 fix-queue-deadlock
+fix-pjsip-channel-creation-deadlock


### PR DESCRIPTION
This branch has been pushed on asterisk-rc and is being run on the load infrastructure. If it does not break anything we should be able to merge it in master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SIP channel initialization/locking order, which can impact call setup behavior and concurrency; however the change is small and localized to packaging a single upstream patch.
> 
> **Overview**
> Adds a new Debian patch (`debian/patches/fix-pjsip-channel-creation-deadlock`) that changes `chan_pjsip.c` channel setup to call `ast_channel_stage_snapshot_done()` and `ast_channel_unlock()` *before* looping over `endpoint->channel_vars`, avoiding deadlocks when variable evaluation triggers dialplan functions.
> 
> Wires the patch into the package build via `debian/patches/series` and bumps `debian/changelog` to `8:22.8.2-2~wazo1` noting the deadlock fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd951e2e0572f596afb52eca07c624401d3a94d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->