### PR TITLE
Update pjsip channel creation deadlock patch: re-lock for snapshot

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.8.2-2~wazo3) wazo-dev-bookworm; urgency=medium
+
+  * update channel creation deadlock patch
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 20 Apr 2026 11:00:43 -0400
+
 asterisk (8:22.8.2-2~wazo1) wazo-dev-bookworm; urgency=medium
 
   * Add channel creation deadlock patch

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -1,16 +1,18 @@
-# Set endpoint channel variables after unlock to prevent deadlock
-# when variables invoke dialplan functions (e.g., PJSIP_HEADER)
-# that block on serializer tasks while the channel lock is held.
-# pbx_builtin_setvar_helper will acquire and release channel lock on each invocation in the loop
+# Fix deadlock in chan_pjsip_new when endpoint set_var uses PJSIP_HEADER.
+# Unlock channel before iterating endpoint channel_vars so that dialplan
+# functions (e.g. PJSIP_HEADER) can block on serializer tasks without
+# holding the channel lock. Re-lock for ast_channel_stage_snapshot_done()
+# so the batched snapshot is published under lock.
+# pbx_builtin_setvar_helper acquires/releases channel lock on its own.
+# Upstream: https://github.com/asterisk/asterisk/pull/1873
 Index: asterisk-22.8.2/channels/chan_pjsip.c
 ===================================================================
 --- asterisk-22.8.2.orig/channels/chan_pjsip.c
 +++ asterisk-22.8.2/channels/chan_pjsip.c
-@@ -665,15 +665,15 @@ static struct ast_channel *chan_pjsip_ne
+@@ -665,13 +665,16 @@ static struct ast_channel *chan_pjsip_ne
  		ast_channel_zone_set(chan, zone);
  	}
- 
-+	ast_channel_stage_snapshot_done(chan);
+
 +	ast_channel_unlock(chan);
 +
  	for (var = session->endpoint->channel_vars; var; var = var->next) {
@@ -18,10 +20,9 @@ Index: asterisk-22.8.2/channels/chan_pjsip.c
  		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
  					var->value, buf, sizeof(buf)));
  	}
- 
--	ast_channel_stage_snapshot_done(chan);
--	ast_channel_unlock(chan);
--
+
++	ast_channel_lock(chan);
+ 	ast_channel_stage_snapshot_done(chan);
+ 	ast_channel_unlock(chan);
+
  	set_channel_on_rtp_instance(session, ast_channel_uniqueid(chan));
- 
- 	SCOPE_EXIT_RTN_VALUE(chan);

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -4,7 +4,6 @@
 # holding the channel lock. Re-lock for ast_channel_stage_snapshot_done()
 # so the batched snapshot is published under lock.
 # pbx_builtin_setvar_helper acquires/releases channel lock on its own.
-# Upstream: https://github.com/asterisk/asterisk/pull/1873
 Index: asterisk-22.8.2/channels/chan_pjsip.c
 ===================================================================
 --- asterisk-22.8.2.orig/channels/chan_pjsip.c


### PR DESCRIPTION
## Summary

asterisk dev caught an issue on mailing list, after sharing patch.

> Updates the `fix-pjsip-channel-creation-deadlock` patch to re-lock the channel around `ast_channel_stage_snapshot_done()` after the `channel_vars` loop.
> 
> **Previous patch:** moved both `ast_channel_stage_snapshot_done()` and `ast_channel_unlock()` before the vars loop. This prevented the deadlock but published the batched snapshot before channel variables were set.
> 
> **Updated patch:** unlocks the channel before the vars loop, then re-locks after it for `ast_channel_stage_snapshot_done()`. This way:
> - Dialplan functions like `PJSIP_HEADER` can block on serializer tasks without holding the channel lock (fixes the deadlock)
> - `ast_channel_stage_snapshot_done()` runs under channel lock as required
> - The batched snapshot captures the full channel state including variables set during the loop
> 
> Follows upstream PR: https://github.com/asterisk/asterisk/pull/1873
> Upstream issue: https://github.com/asterisk/asterisk/issues/1874


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level channel locking/snapshot sequencing in `chan_pjsip_new`, so mistakes could reintroduce deadlocks or produce inconsistent channel state during call setup, but the change is small and targeted.
> 
> **Overview**
> Updates the Debian `fix-pjsip-channel-creation-deadlock` patch for Asterisk 22 so `chan_pjsip_new` unlocks the channel while applying `endpoint->channel_vars`, then **re-locks** around `ast_channel_stage_snapshot_done()` to publish the batched snapshot under the required lock (and after variables are set).
> 
> Bumps `debian/changelog` with a new package revision noting the patch update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bbc1a58173888d4ab8e0ef666f2e92783d3b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->