### PR TITLE
[ITEM-361] asterisk 22.9.0 + patches

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+asterisk (8:22.9.0-1~wazo3) wazo-dev-bookworm; urgency=medium
+
+  * add RTP ioqueue thread destroy patch from asterisk upstream
+    (https://github.com/asterisk/asterisk/pull/1870)
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 04 Jun 2026 10:41:04 -0400
+
 asterisk (8:22.9.0-1~wazo2) wazo-dev-bookworm; urgency=medium
 
   * add PJSIP reload deadlock patch from asterisk upstream

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+asterisk (8:22.9.0-1~wazo2) wazo-dev-bookworm; urgency=medium
+
+  * add PJSIP reload deadlock patch from asterisk upstream
+    (https://github.com/asterisk/asterisk/pull/1856)
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 29 Apr 2026 14:19:07 -0400
+
 asterisk (8:22.9.0-1~wazo1) wazo-dev-bookworm; urgency=medium
 
   * asterisk 22.9.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk (8:22.9.0-1~wazo1) wazo-dev-bookworm; urgency=medium
+
+  * asterisk 22.9.0
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Wed, 29 Apr 2026 10:24:20 -0400
+
 asterisk (8:22.8.2-2~wazo3) wazo-dev-bookworm; urgency=medium
 
   * update channel creation deadlock patch

--- a/debian/patches/1867-ioqueue-destroy-fd-leak
+++ b/debian/patches/1867-ioqueue-destroy-fd-leak
@@ -1,0 +1,12 @@
+Index: asterisk-22.9.0/res/res_rtp_asterisk.c
+===================================================================
+--- asterisk-22.9.0.orig/res/res_rtp_asterisk.c
++++ asterisk-22.9.0/res/res_rtp_asterisk.c
+@@ -1540,6 +1540,7 @@ static void rtp_ioqueue_thread_destroy(s
+ 		pj_pool_t *temp_pool = ioqueue->pool;
+ 
+ 		ioqueue->pool = NULL;
++		pj_ioqueue_destroy(ioqueue->ioqueue);
+ 		pj_pool_release(temp_pool);
+ 	}
+ 

--- a/debian/patches/deb_astgenkey-security
+++ b/debian/patches/deb_astgenkey-security
@@ -6,10 +6,10 @@ Last-Update: 2009-12-19
 Upstream has not accepted this patch and chose intead to document this 
 as a known minor issue.
 
-Index: asterisk-22.8.2/contrib/scripts/astgenkey
+Index: asterisk-22.9.0/contrib/scripts/astgenkey
 ===================================================================
---- asterisk-22.8.2.orig/contrib/scripts/astgenkey
-+++ asterisk-22.8.2/contrib/scripts/astgenkey
+--- asterisk-22.9.0.orig/contrib/scripts/astgenkey
++++ asterisk-22.9.0/contrib/scripts/astgenkey
 @@ -47,7 +47,11 @@ done
  rm -f ${KEY}.key ${KEY}.pub
  

--- a/debian/patches/deb_make-clean-fixes
+++ b/debian/patches/deb_make-clean-fixes
@@ -3,11 +3,11 @@ Author: Faidon Liambotis <paravoid@debian.org>
 Forwarded: not-needed
 Last-Update: 2009-12-19
 
-Index: asterisk-22.8.2/Makefile
+Index: asterisk-22.9.0/Makefile
 ===================================================================
---- asterisk-22.8.2.orig/Makefile
-+++ asterisk-22.8.2/Makefile
-@@ -447,7 +447,6 @@ dist-clean: distclean
+--- asterisk-22.9.0.orig/Makefile
++++ asterisk-22.9.0/Makefile
+@@ -449,7 +449,6 @@ dist-clean: distclean
  
  distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	@$(MAKE) -C menuselect dist-clean
@@ -15,7 +15,7 @@ Index: asterisk-22.8.2/Makefile
  	rm -f menuselect.makeopts makeopts menuselect-tree menuselect.makedeps
  	rm -f config.log config.status config.cache
  	rm -rf autom4te.cache
-@@ -457,6 +456,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
+@@ -459,6 +458,10 @@ distclean: $(SUBDIRS_DIST_CLEAN) _clean
  	rm -f doc/Doxyfile
  	rm -f build_tools/menuselect-deps
  

--- a/debian/patches/expose-app-queues-mutex
+++ b/debian/patches/expose-app-queues-mutex
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -2216,6 +2216,9 @@ static int op_value_get(struct op_value
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -2239,6 +2239,9 @@ static int op_value_get(struct op_value
  static void op_value_set(struct op_value *op_value, int value);
  static void op_value_undef(struct op_value *op_value);
  
@@ -12,7 +12,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  /*! \brief sets the QUEUESTATUS channel variable */
  static void set_queue_result(struct ast_channel *chan, enum queue_result res)
  {
-@@ -13477,6 +13480,11 @@ static void op_value_undef(struct op_val
+@@ -13576,6 +13579,11 @@ static void op_value_undef(struct op_val
  	op_value->defined = 0;
  }
  
@@ -24,7 +24,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  static struct ast_cli_entry cli_queue[] = {
  	AST_CLI_DEFINE(queue_show, "Show status of a specified queue"),
  	AST_CLI_DEFINE(handle_queue_rule_show, "Show the rules defined in queuerules.conf"),
-@@ -13723,7 +13731,7 @@ static int load_module(void)
+@@ -13822,7 +13830,7 @@ static int load_module(void)
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -33,10 +33,10 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
  	.unload = unload_module,
-Index: asterisk-22.8.2/apps/app_queue.exports.in
+Index: asterisk-22.9.0/apps/app_queue.exports.in
 ===================================================================
 --- /dev/null
-+++ asterisk-22.8.2/apps/app_queue.exports.in
++++ asterisk-22.9.0/apps/app_queue.exports.in
 @@ -0,0 +1,6 @@
 +{
 +	global:

--- a/debian/patches/fix-application-playback-update
+++ b/debian/patches/fix-application-playback-update
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/res/res_stasis_playback.c
+Index: asterisk-22.9.0/res/res_stasis_playback.c
 ===================================================================
---- asterisk-22.8.2.orig/res/res_stasis_playback.c
-+++ asterisk-22.8.2/res/res_stasis_playback.c
+--- asterisk-22.9.0.orig/res/res_stasis_playback.c
++++ asterisk-22.9.0/res/res_stasis_playback.c
 @@ -344,7 +344,8 @@ static void play_on_channel(struct stasi
  			if (!recording) {
  				ast_log(LOG_ERROR, "Attempted to play recording '%s' on channel '%s' but recording does not exist",

--- a/debian/patches/fix-invalid-moh
+++ b/debian/patches/fix-invalid-moh
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/res/res_musiconhold.c
+Index: asterisk-22.9.0/res/res_musiconhold.c
 ===================================================================
---- asterisk-22.8.2.orig/res/res_musiconhold.c
-+++ asterisk-22.8.2/res/res_musiconhold.c
+--- asterisk-22.9.0.orig/res/res_musiconhold.c
++++ asterisk-22.9.0/res/res_musiconhold.c
 @@ -413,7 +413,9 @@ static int moh_files_next(struct ast_cha
  		state->samples = 0;
  	}

--- a/debian/patches/fix-pjsip-channel-creation-deadlock
+++ b/debian/patches/fix-pjsip-channel-creation-deadlock
@@ -4,14 +4,14 @@
 # holding the channel lock. Re-lock for ast_channel_stage_snapshot_done()
 # so the batched snapshot is published under lock.
 # pbx_builtin_setvar_helper acquires/releases channel lock on its own.
-Index: asterisk-22.8.2/channels/chan_pjsip.c
+Index: asterisk-22.9.0/channels/chan_pjsip.c
 ===================================================================
---- asterisk-22.8.2.orig/channels/chan_pjsip.c
-+++ asterisk-22.8.2/channels/chan_pjsip.c
-@@ -665,13 +665,16 @@ static struct ast_channel *chan_pjsip_ne
+--- asterisk-22.9.0.orig/channels/chan_pjsip.c
++++ asterisk-22.9.0/channels/chan_pjsip.c
+@@ -665,12 +665,15 @@ static struct ast_channel *chan_pjsip_ne
  		ast_channel_zone_set(chan, zone);
  	}
-
+ 
 +	ast_channel_unlock(chan);
 +
  	for (var = session->endpoint->channel_vars; var; var = var->next) {
@@ -19,9 +19,8 @@ Index: asterisk-22.8.2/channels/chan_pjsip.c
  		pbx_builtin_setvar_helper(chan, var->name, ast_get_encoded_str(
  					var->value, buf, sizeof(buf)));
  	}
-
+ 
 +	ast_channel_lock(chan);
  	ast_channel_stage_snapshot_done(chan);
  	ast_channel_unlock(chan);
-
- 	set_channel_on_rtp_instance(session, ast_channel_uniqueid(chan));
+ 

--- a/debian/patches/fix-queue-deadlock
+++ b/debian/patches/fix-queue-deadlock
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -1995,6 +1995,15 @@ struct skills_group {
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -2014,6 +2014,15 @@ struct skills_group {
  
  static AST_LIST_HEAD_STATIC(skills_groups, skills_group);
  
@@ -18,7 +18,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  struct member {
  	char interface[AST_CHANNEL_NAME];    /*!< Technology/Location to dial to reach this member*/
  	char state_exten[AST_MAX_EXTENSION]; /*!< Extension to get state from (if using hint) */
-@@ -2023,6 +2032,7 @@ struct member {
+@@ -2042,6 +2051,7 @@ struct member {
  	unsigned int delme:1;                /*!< Flag to delete entry on reload */
  	char rt_uniqueid[80];                /*!< Unique id of realtime member entry */
  	unsigned int ringinuse:1;            /*!< Flag to ring queue members even if their status is 'inuse' */
@@ -26,7 +26,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  };
  
  enum empty_conditions {
-@@ -2176,6 +2186,18 @@ static AST_LIST_HEAD_STATIC(rule_lists,
+@@ -2199,6 +2209,18 @@ static AST_LIST_HEAD_STATIC(rule_lists,
  
  static struct ao2_container *queues;
  
@@ -45,7 +45,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  static void update_realtime_members(struct call_queue *q);
  static struct member *interface_exists(struct call_queue *q, const char *interface);
  static int set_member_paused(const char *queuename, const char *interface, const char *reason, int paused);
-@@ -2740,11 +2762,11 @@ static struct ast_json *queue_member_blo
+@@ -2763,11 +2785,11 @@ static struct ast_json *queue_member_blo
  		"StateInterface", mem->state_interface,
  		"Membership", (mem->dynamic ? "dynamic" : (mem->realtime ? "realtime" : "static")),
  		"Penalty", mem->penalty,
@@ -60,7 +60,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		"Status", mem->status,
  		"Paused", mem->paused,
  		"PausedReason", mem->reason_paused,
-@@ -2826,11 +2848,11 @@ static int get_member_status(struct call
+@@ -2849,11 +2871,11 @@ static int get_member_status(struct call
  				ast_debug(4, "%s is unavailable because he is paused'\n", member->membername);
  				break;
  			} else if ((conditions & QUEUE_EMPTY_WRAPUP)
@@ -75,7 +75,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				break;
  			} else {
  				ao2_ref(member, -1);
-@@ -2930,7 +2952,7 @@ static void update_status(struct call_qu
+@@ -2953,7 +2975,7 @@ static void update_status(struct call_qu
  		 * considered done and the call finished.
  		 */
  		if (status == AST_DEVICE_NOT_INUSE) {
@@ -84,7 +84,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		}
  
  		m->status = status;
-@@ -2958,6 +2980,7 @@ static int is_member_available(struct ca
+@@ -2981,6 +3003,7 @@ static int is_member_available(struct ca
  {
  	int available = 0;
  	int wrapuptime;
@@ -92,7 +92,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  	switch (mem->status) {
  		case AST_DEVICE_INVALID:
-@@ -2983,7 +3006,8 @@ static int is_member_available(struct ca
+@@ -3006,7 +3029,8 @@ static int is_member_available(struct ca
  
  	/* Let wrapuptimes override device state availability */
  	wrapuptime = get_wrapuptime(q, mem);
@@ -102,7 +102,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		available = 0;
  	}
  	return available;
-@@ -3211,12 +3235,28 @@ static void destroy_queue_member_cb(void
+@@ -3234,12 +3258,28 @@ static void destroy_queue_member_cb(void
  	if (mem->state_id != -1) {
  		ast_extension_state_del(mem->state_id, extension_state_cb);
  	}
@@ -132,7 +132,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  	if ((cur = ao2_alloc(sizeof(*cur), destroy_queue_member_cb))) {
  		cur->ringinuse = ringinuse;
-@@ -3257,6 +3297,34 @@ static struct member *create_queue_membe
+@@ -3280,6 +3320,34 @@ static struct member *create_queue_membe
  			ast_copy_string(cur->skills, skills, sizeof(cur->skills));
  		else
  			cur->skills[0] = '\0';
@@ -167,7 +167,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	}
  
  	return cur;
-@@ -3417,10 +3485,10 @@ static void clear_queue(struct call_queu
+@@ -3440,10 +3508,10 @@ static void clear_queue(struct call_queu
  		struct member *mem;
  		struct ao2_iterator mem_iter = ao2_iterator_init(q->members, 0);
  		while ((mem = ao2_iterator_next(&mem_iter))) {
@@ -182,7 +182,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			ao2_ref(mem, -1);
  		}
  		ao2_iterator_destroy(&mem_iter);
-@@ -5078,6 +5146,7 @@ static int member_status_available(int s
+@@ -5111,6 +5179,7 @@ static int member_status_available(int s
  static int can_ring_entry(struct queue_ent *qe, struct callattempt *call, int *busies)
  {
  	struct member *memberp = call->member;
@@ -190,7 +190,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int wrapuptime;
  
  	if (memberp->paused) {
-@@ -5090,14 +5159,14 @@ static int can_ring_entry(struct queue_e
+@@ -5123,14 +5192,14 @@ static int can_ring_entry(struct queue_e
  		return 0;
  	}
  
@@ -209,7 +209,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			call->interface);
  		return 0;
  	}
-@@ -5560,8 +5629,8 @@ static void rna(int rnatime, struct queu
+@@ -5593,8 +5662,8 @@ static void rna(int rnatime, struct queu
  			struct member *mem;
  			ao2_lock(qe->parent);
  			if ((mem = interface_exists(qe->parent, interface))) {
@@ -220,7 +220,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  					ao2_unlock(qe->parent);
  					ao2_ref(mem, -1);
  					return;
-@@ -6401,6 +6470,141 @@ static int wait_our_turn(struct queue_en
+@@ -6434,6 +6503,141 @@ static int wait_our_turn(struct queue_en
  }
  
  /*!
@@ -362,7 +362,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
   * \brief update the queue status
   * \retval 0 always
  */
-@@ -6408,43 +6612,23 @@ static int update_queue(struct call_queu
+@@ -6441,43 +6645,23 @@ static int update_queue(struct call_queu
  {
  	int oldtalktime;
  	int newtalktime = time(NULL) - starttime;
@@ -415,7 +415,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	/* Member might never experience any direct status change (local
  	 * channel with forwarding in particular). If that's the case,
  	 * this is the last chance to remove it from pending or subsequent
-@@ -6536,14 +6720,14 @@ static int calc_metric(struct call_queue
+@@ -6569,14 +6753,14 @@ static int calc_metric(struct call_queue
  		tmp->metric = ast_random() % ((1 + penalty) * 1000);
  		break;
  	case QUEUE_STRATEGY_FEWESTCALLS:
@@ -433,7 +433,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		}
  		tmp->metric += penalty * 1000000 * usepenalty;
  		break;
-@@ -7638,7 +7822,8 @@ static int try_calling(struct queue_ent
+@@ -7700,7 +7884,8 @@ static int try_calling(struct queue_ent
  		recalc_holdtime(qe, (now - qe->start));
  		member = lpeer->member;
  		ao2_lock(qe->parent);
@@ -443,7 +443,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		ao2_unlock(qe->parent);
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
-@@ -7747,7 +7932,7 @@ static int try_calling(struct queue_ent
+@@ -7809,7 +7994,7 @@ static int try_calling(struct queue_ent
  		/* use  pbx_builtin_setvar to set a load of variables with one call */
  		if (qe->parent->setinterfacevar && interfacevar) {
  			ast_str_set(&interfacevar, 0, "MEMBERINTERFACE=%s,MEMBERNAME=%s,MEMBERCALLS=%d,MEMBERLASTCALL=%ld,MEMBERPENALTY=%d,MEMBERDYNAMIC=%d,MEMBERREALTIME=%d",
@@ -452,7 +452,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			pbx_builtin_setvar_multiple(qe->chan, ast_str_buffer(interfacevar));
  			pbx_builtin_setvar_multiple(peer, ast_str_buffer(interfacevar));
  		}
-@@ -7871,8 +8056,8 @@ static int try_calling(struct queue_ent
+@@ -7936,8 +8121,8 @@ static int try_calling(struct queue_ent
  		}
  
  		ao2_lock(qe->parent);
@@ -463,7 +463,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		ao2_unlock(qe->parent);
  		/* As a queue member may end up in multiple calls at once if a transfer occurs with
  		 * a Local channel in the mix we pass the current call information (starttime) to the
-@@ -9604,7 +9789,7 @@ static int queue_function_mem_read(struc
+@@ -9697,7 +9882,7 @@ static int queue_function_mem_read(struc
  			while ((m = ao2_iterator_next(&mem_iter))) {
  				/* Count the agents who are logged in, not paused and not wrapping up */
  				if ((m->status == AST_DEVICE_NOT_INUSE) && (!m->paused) &&
@@ -472,7 +472,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  					count++;
  				}
  				ao2_ref(m, -1);
-@@ -10278,8 +10463,8 @@ static void reload_single_member(const c
+@@ -10377,8 +10562,8 @@ static void reload_single_member(const c
  			/* Round Robin Queue Position must be copied if this is replacing an existing member */
  			newm->queuepos = cur->queuepos;
  			/* Don't reset agent stats either */
@@ -483,7 +483,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  			ao2_link(q->members, newm);
  			ao2_unlink(q->members, cur);
-@@ -10658,7 +10843,7 @@ static void print_queue(struct mansessio
+@@ -10757,7 +10942,7 @@ static void print_queue(struct mansessio
  			ast_str_append(&out, 0, "%s%s%s%s%s%s%s%s%s",
  				mem->dynamic ? ast_term_color(COLOR_CYAN, COLOR_BLACK) : "", mem->dynamic ? " (dynamic)" : "", ast_term_reset(),
  				mem->realtime ? ast_term_color(COLOR_MAGENTA, COLOR_BLACK) : "", mem->realtime ? " (realtime)" : "", ast_term_reset(),
@@ -492,7 +492,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  			if (mem->paused) {
  				ast_str_append(&out, 0, " %s(paused%s%s was %ld secs ago)%s",
-@@ -10676,9 +10861,9 @@ static void print_queue(struct mansessio
+@@ -10775,9 +10960,9 @@ static void print_queue(struct mansessio
  					ast_devstate2str(mem->status), ast_term_reset());
  			if (!ast_strlen_zero(mem->skills))
  				ast_str_append(&out, 0, " (skills: %s)", mem->skills);
@@ -504,7 +504,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			} else {
  				ast_str_append(&out, 0, " has taken no calls yet");
  			}
-@@ -11176,7 +11361,7 @@ static int manager_queues_status(struct
+@@ -11275,7 +11460,7 @@ static int manager_queues_status(struct
  						"%s"
  						"\r\n",
  						q->name, mem->membername, mem->interface, mem->state_interface, mem->dynamic ? "dynamic" : "static",
@@ -513,7 +513,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  						mem->paused, mem->reason_paused, mem->wrapuptime, mem->skills, idText);
  					++q_items;
  				}
-@@ -12275,17 +12460,16 @@ static int qupd_exec(struct ast_channel
+@@ -12374,17 +12559,16 @@ static int qupd_exec(struct ast_channel
  				if (!strcasecmp(args.status, "ANSWER")) {
  					oldtalktime = q->talktime;
  					q->talktime = (((oldtalktime << 2) - oldtalktime) + newtalktime) >> 2;

--- a/debian/patches/increase-max-sdp-media
+++ b/debian/patches/increase-max-sdp-media
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/third-party/pjproject/patches/config_site.h
+Index: asterisk-22.9.0/third-party/pjproject/patches/config_site.h
 ===================================================================
---- asterisk-22.8.2.orig/third-party/pjproject/patches/config_site.h
-+++ asterisk-22.8.2/third-party/pjproject/patches/config_site.h
+--- asterisk-22.9.0.orig/third-party/pjproject/patches/config_site.h
++++ asterisk-22.9.0/third-party/pjproject/patches/config_site.h
 @@ -87,7 +87,7 @@
  #define	PJMEDIA_MAX_SDP_FMT   72
  #define	PJMEDIA_MAX_SDP_BANDW   4

--- a/debian/patches/mix_monitor_announce_file
+++ b/debian/patches/mix_monitor_announce_file
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/apps/app_mixmonitor.c
+Index: asterisk-22.9.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_mixmonitor.c
-+++ asterisk-22.8.2/apps/app_mixmonitor.c
+--- asterisk-22.9.0.orig/apps/app_mixmonitor.c
++++ asterisk-22.9.0/apps/app_mixmonitor.c
 @@ -147,10 +147,14 @@
  						<para>Stores the MixMonitor's ID on this channel variable.</para>
  					</option>

--- a/debian/patches/mixmonitor_close_beep_file
+++ b/debian/patches/mixmonitor_close_beep_file
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/apps/app_mixmonitor.c
+Index: asterisk-22.9.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_mixmonitor.c
-+++ asterisk-22.8.2/apps/app_mixmonitor.c
+--- asterisk-22.9.0.orig/apps/app_mixmonitor.c
++++ asterisk-22.9.0/apps/app_mixmonitor.c
 @@ -945,7 +945,9 @@ frame_cleanup:
  
  	if (ast_test_flag(mixmonitor, MUXFLAG_BEEP_STOP)) {

--- a/debian/patches/pjsip-fix-reload-deadlock
+++ b/debian/patches/pjsip-fix-reload-deadlock
@@ -1,0 +1,32 @@
+Index: asterisk-22.9.0/res/res_pjsip_config_wizard.c
+===================================================================
+--- asterisk-22.9.0.orig/res/res_pjsip_config_wizard.c
++++ asterisk-22.9.0/res/res_pjsip_config_wizard.c
+@@ -1331,9 +1331,26 @@ static struct ast_cli_entry config_wizar
+ 	AST_CLI_DEFINE(handle_export_primitives, "Export config wizard primitives"),
+ };
+ 
++/*!
++ * \internal
++ * \brief Reload configuration within a PJSIP thread
++ */
++static int reload_configuration_task(void *obj)
++{
++	struct ast_sorcery *sip_sorcery = ast_sip_get_sorcery();
++	if (sip_sorcery) {
++		ast_sorcery_reload(sip_sorcery);
++	}
++	return 0;
++}
++
+ static int reload_module(void)
+ {
+-	ast_sorcery_reload(ast_sip_get_sorcery());
++	if (ast_sip_push_task_wait_servant(NULL, reload_configuration_task, NULL)) {
++		ast_log(LOG_WARNING, "Failed to reload PJSIP\n");
++		return -1;
++	}
++
+ 	return 0;
+ }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -31,3 +31,4 @@ expose-app-queues-mutex
 fix-queue-deadlock
 fix-pjsip-channel-creation-deadlock
 pjsip-fix-reload-deadlock
+1867-ioqueue-destroy-fd-leak

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -30,3 +30,4 @@ fix-application-playback-update
 expose-app-queues-mutex
 fix-queue-deadlock
 fix-pjsip-channel-creation-deadlock
+pjsip-fix-reload-deadlock

--- a/debian/patches/wazo_ari_expose_voicemail_functions
+++ b/debian/patches/wazo_ari_expose_voicemail_functions
@@ -1,16 +1,16 @@
-Index: asterisk-22.8.2/res/ari.make
+Index: asterisk-22.9.0/res/ari.make
 ===================================================================
---- asterisk-22.8.2.orig/res/ari.make
-+++ asterisk-22.8.2/res/ari.make
+--- asterisk-22.9.0.orig/res/ari.make
++++ asterisk-22.9.0/res/ari.make
 @@ -28,3 +28,4 @@ $(call MOD_ADD_C,res_ari_device_states,a
  $(call MOD_ADD_C,res_ari_mailboxes,ari/resource_mailboxes.c)
  $(call MOD_ADD_C,res_ari_events,ari/resource_events.c)
  $(call MOD_ADD_C,res_ari_applications,ari/resource_applications.c)
 +$(call MOD_ADD_C,res_ari_wazo,ari/resource_wazo.c)
-Index: asterisk-22.8.2/res/ari/resource_wazo.c
+Index: asterisk-22.9.0/res/ari/resource_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-22.8.2/res/ari/resource_wazo.c
++++ asterisk-22.9.0/res/ari/resource_wazo.c
 @@ -0,0 +1,417 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -429,10 +429,10 @@ Index: asterisk-22.8.2/res/ari/resource_wazo.c
 +static int validate_greeting(const char *greeting) {
 +      return !strcmp(greeting, "unavailable") || !strcmp(greeting, "busy") || !strcmp(greeting, "name");
 +}
-Index: asterisk-22.8.2/res/ari/resource_wazo.h
+Index: asterisk-22.9.0/res/ari/resource_wazo.h
 ===================================================================
 --- /dev/null
-+++ asterisk-22.8.2/res/ari/resource_wazo.h
++++ asterisk-22.9.0/res/ari/resource_wazo.h
 @@ -0,0 +1,200 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -634,10 +634,10 @@ Index: asterisk-22.8.2/res/ari/resource_wazo.h
 +void ast_ari_wazo_remove_voicemail_greeting(struct ast_variable *headers, struct ast_ari_wazo_remove_voicemail_greeting_args *args, struct ast_ari_response *response);
 +
 +#endif /* _ASTERISK_RESOURCE_WAZO_H */
-Index: asterisk-22.8.2/res/res_ari_wazo.c
+Index: asterisk-22.9.0/res/res_ari_wazo.c
 ===================================================================
 --- /dev/null
-+++ asterisk-22.8.2/res/res_ari_wazo.c
++++ asterisk-22.9.0/res/res_ari_wazo.c
 @@ -0,0 +1,608 @@
 +/*
 + * Asterisk -- An open source telephony toolkit.
@@ -1247,10 +1247,10 @@ Index: asterisk-22.8.2/res/res_ari_wazo.c
 +	.unload = unload_module,
 +	.requires = "res_ari,res_ari_model,res_stasis",
 +);
-Index: asterisk-22.8.2/rest-api/api-docs/wazo.json
+Index: asterisk-22.9.0/rest-api/api-docs/wazo.json
 ===================================================================
 --- /dev/null
-+++ asterisk-22.8.2/rest-api/api-docs/wazo.json
++++ asterisk-22.9.0/rest-api/api-docs/wazo.json
 @@ -0,0 +1,296 @@
 +{
 +	"_copyright": "Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)",
@@ -1548,10 +1548,10 @@ Index: asterisk-22.8.2/rest-api/api-docs/wazo.json
 +		}
 +	}
 +}
-Index: asterisk-22.8.2/rest-api/resources.json
+Index: asterisk-22.9.0/rest-api/resources.json
 ===================================================================
---- asterisk-22.8.2.orig/rest-api/resources.json
-+++ asterisk-22.8.2/rest-api/resources.json
+--- asterisk-22.9.0.orig/rest-api/resources.json
++++ asterisk-22.9.0/rest-api/resources.json
 @@ -49,6 +49,10 @@
  		{
  			"path": "/api-docs/applications.{format}",
@@ -1563,10 +1563,10 @@ Index: asterisk-22.8.2/rest-api/resources.json
  		}
  	]
  }
-Index: asterisk-22.8.2/include/asterisk/app.h
+Index: asterisk-22.9.0/include/asterisk/app.h
 ===================================================================
---- asterisk-22.8.2.orig/include/asterisk/app.h
-+++ asterisk-22.8.2/include/asterisk/app.h
+--- asterisk-22.9.0.orig/include/asterisk/app.h
++++ asterisk-22.9.0/include/asterisk/app.h
 @@ -518,6 +518,19 @@ typedef int (ast_vm_msg_forward_fn)(cons
  typedef int (ast_vm_msg_play_fn)(struct ast_channel *chan, const char *mailbox,
  	const char *context, const char *folder, const char *msg_num, ast_vm_msg_play_cb *cb);
@@ -1656,10 +1656,10 @@ Index: asterisk-22.8.2/include/asterisk/app.h
  /*!
   * \brief Initialize the application core
   * \retval 0 Success
-Index: asterisk-22.8.2/main/app.c
+Index: asterisk-22.9.0/main/app.c
 ===================================================================
---- asterisk-22.8.2.orig/main/app.c
-+++ asterisk-22.8.2/main/app.c
+--- asterisk-22.9.0.orig/main/app.c
++++ asterisk-22.9.0/main/app.c
 @@ -736,6 +736,58 @@ int ast_vm_msg_play(struct ast_channel *
  	return res;
  }
@@ -1719,10 +1719,10 @@ Index: asterisk-22.8.2/main/app.c
  #ifdef TEST_FRAMEWORK
  int ast_vm_test_create_user(const char *context, const char *mailbox)
  {
-Index: asterisk-22.8.2/apps/app_voicemail.c
+Index: asterisk-22.9.0/apps/app_voicemail.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_voicemail.c
-+++ asterisk-22.8.2/apps/app_voicemail.c
+--- asterisk-22.9.0.orig/apps/app_voicemail.c
++++ asterisk-22.9.0/apps/app_voicemail.c
 @@ -713,6 +713,10 @@ static AST_LIST_HEAD_STATIC(vmstates, vm
  #define ENDL "\n"
  #endif
@@ -1957,11 +1957,11 @@ Index: asterisk-22.8.2/apps/app_voicemail.c
  /* This is a workaround so that menuselect displays a proper description
   * AST_MODULE_INFO(, , "Comedian Mail (Voicemail System)"
   */
-Index: asterisk-22.8.2/main/http.c
+Index: asterisk-22.9.0/main/http.c
 ===================================================================
---- asterisk-22.8.2.orig/main/http.c
-+++ asterisk-22.8.2/main/http.c
-@@ -82,7 +82,7 @@
+--- asterisk-22.9.0.orig/main/http.c
++++ asterisk-22.9.0/main/http.c
+@@ -83,7 +83,7 @@
  
  /*! Maximum application/json or application/x-www-form-urlencoded body content length. */
  #if !defined(LOW_MEMORY)
@@ -1970,10 +1970,10 @@ Index: asterisk-22.8.2/main/http.c
  #else
  #define MAX_CONTENT_LENGTH 1024
  #endif	/* !defined(LOW_MEMORY) */
-Index: asterisk-22.8.2/res/ari/ari_model_validators.c
+Index: asterisk-22.9.0/res/ari/ari_model_validators.c
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/ari_model_validators.c
-+++ asterisk-22.8.2/res/ari/ari_model_validators.c
+--- asterisk-22.9.0.orig/res/ari/ari_model_validators.c
++++ asterisk-22.9.0/res/ari/ari_model_validators.c
 @@ -8744,3 +8744,41 @@ ari_validator ast_ari_validate_applicati
  {
  	return ast_ari_validate_application;
@@ -2016,10 +2016,10 @@ Index: asterisk-22.8.2/res/ari/ari_model_validators.c
 +{
 +	return ast_ari_validate_encoded_file;
 +}
-Index: asterisk-22.8.2/res/ari/ari_model_validators.h
+Index: asterisk-22.9.0/res/ari/ari_model_validators.h
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/ari_model_validators.h
-+++ asterisk-22.8.2/res/ari/ari_model_validators.h
+--- asterisk-22.9.0.orig/res/ari/ari_model_validators.h
++++ asterisk-22.9.0/res/ari/ari_model_validators.h
 @@ -1503,6 +1503,22 @@ int ast_ari_validate_application(struct
   */
  ari_validator ast_ari_validate_application_fn(void);

--- a/debian/patches/wazo_banner
+++ b/debian/patches/wazo_banner
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/main/asterisk.c
+Index: asterisk-22.9.0/main/asterisk.c
 ===================================================================
---- asterisk-22.8.2.orig/main/asterisk.c
-+++ asterisk-22.8.2/main/asterisk.c
+--- asterisk-22.9.0.orig/main/asterisk.c
++++ asterisk-22.9.0/main/asterisk.c
 @@ -315,6 +315,10 @@ int daemon(int, int);  /* defined in lib
                  "This is free software, with components licensed under the GNU General Public\n" \
                  "License version 2 and other licenses; you are welcome to redistribute it under\n" \

--- a/debian/patches/wazo_bridge_variables
+++ b/debian/patches/wazo_bridge_variables
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/include/asterisk/bridge.h
+Index: asterisk-22.9.0/include/asterisk/bridge.h
 ===================================================================
---- asterisk-22.8.2.orig/include/asterisk/bridge.h
-+++ asterisk-22.8.2/include/asterisk/bridge.h
+--- asterisk-22.9.0.orig/include/asterisk/bridge.h
++++ asterisk-22.9.0/include/asterisk/bridge.h
 @@ -253,6 +253,31 @@ typedef void (*ast_bridge_notify_masquer
  typedef int (*ast_bridge_merge_priority_fn)(struct ast_bridge *self);
  
@@ -85,10 +85,10 @@ Index: asterisk-22.8.2/include/asterisk/bridge.h
  #if defined(__cplusplus) || defined(c_plusplus)
  }
  #endif
-Index: asterisk-22.8.2/main/bridge.c
+Index: asterisk-22.9.0/main/bridge.c
 ===================================================================
---- asterisk-22.8.2.orig/main/bridge.c
-+++ asterisk-22.8.2/main/bridge.c
+--- asterisk-22.9.0.orig/main/bridge.c
++++ asterisk-22.9.0/main/bridge.c
 @@ -127,6 +127,8 @@
  #include "asterisk/core_local.h"
  #include "asterisk/core_unreal.h"
@@ -151,10 +151,10 @@ Index: asterisk-22.8.2/main/bridge.c
  static int manager_bridge_tech_list(struct mansession *s, const struct message *m)
  {
  	const char *id = astman_get_header(m, "ActionID");
-Index: asterisk-22.8.2/res/ari/resource_bridges.c
+Index: asterisk-22.9.0/res/ari/resource_bridges.c
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/resource_bridges.c
-+++ asterisk-22.8.2/res/ari/resource_bridges.c
+--- asterisk-22.9.0.orig/res/ari/resource_bridges.c
++++ asterisk-22.9.0/res/ari/resource_bridges.c
 @@ -44,6 +44,10 @@
  #include "asterisk/file.h"
  #include "asterisk/musiconhold.h"
@@ -288,10 +288,10 @@ Index: asterisk-22.8.2/res/ari/resource_bridges.c
 +	ast_ari_response_ok(response, response->message);
 +}
 \ No newline at end of file
-Index: asterisk-22.8.2/res/ari/resource_bridges.h
+Index: asterisk-22.9.0/res/ari/resource_bridges.h
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/resource_bridges.h
-+++ asterisk-22.8.2/res/ari/resource_bridges.h
+--- asterisk-22.9.0.orig/res/ari/resource_bridges.h
++++ asterisk-22.9.0/res/ari/resource_bridges.h
 @@ -401,5 +401,59 @@ int ast_ari_bridges_record_parse_body(
   * \param[out] response HTTP response
   */
@@ -352,10 +352,10 @@ Index: asterisk-22.8.2/res/ari/resource_bridges.h
 +void ast_ari_bridges_set_bridge_var(struct ast_variable *headers, struct ast_ari_bridges_set_bridge_var_args *args, struct ast_ari_response *response);
  
  #endif /* _ASTERISK_RESOURCE_BRIDGES_H */
-Index: asterisk-22.8.2/res/res_ari_bridges.c
+Index: asterisk-22.9.0/res/res_ari_bridges.c
 ===================================================================
---- asterisk-22.8.2.orig/res/res_ari_bridges.c
-+++ asterisk-22.8.2/res/res_ari_bridges.c
+--- asterisk-22.9.0.orig/res/res_ari_bridges.c
++++ asterisk-22.9.0/res/res_ari_bridges.c
 @@ -1514,6 +1514,179 @@ static void ast_ari_bridges_record_cb(
  fin: __attribute__((unused))
  	return;
@@ -564,10 +564,10 @@ Index: asterisk-22.8.2/res/res_ari_bridges.c
  };
  /*! \brief REST handler for /api-docs/bridges.json */
  static struct stasis_rest_handlers bridges = {
-Index: asterisk-22.8.2/rest-api/api-docs/bridges.json
+Index: asterisk-22.9.0/rest-api/api-docs/bridges.json
 ===================================================================
---- asterisk-22.8.2.orig/rest-api/api-docs/bridges.json
-+++ asterisk-22.8.2/rest-api/api-docs/bridges.json
+--- asterisk-22.9.0.orig/rest-api/api-docs/bridges.json
++++ asterisk-22.9.0/rest-api/api-docs/bridges.json
 @@ -653,7 +653,6 @@
  							"reason": "The format specified is unknown on this system"
  						}
@@ -685,10 +685,10 @@ Index: asterisk-22.8.2/rest-api/api-docs/bridges.json
  				}
  			}
  		}
-Index: asterisk-22.8.2/include/asterisk/stasis_bridges.h
+Index: asterisk-22.9.0/include/asterisk/stasis_bridges.h
 ===================================================================
---- asterisk-22.8.2.orig/include/asterisk/stasis_bridges.h
-+++ asterisk-22.8.2/include/asterisk/stasis_bridges.h
+--- asterisk-22.9.0.orig/include/asterisk/stasis_bridges.h
++++ asterisk-22.9.0/include/asterisk/stasis_bridges.h
 @@ -103,6 +103,9 @@ struct ast_bridge_merge_message {
  	struct ast_bridge_snapshot *to;		/*!< Bridge to which channels will be added during the merge */
  };
@@ -717,10 +717,10 @@ Index: asterisk-22.8.2/include/asterisk/stasis_bridges.h
   * \brief Blob of data associated with a bridge.
   *
   * The \c blob is actually a JSON object of structured data. It has a "type" field
-Index: asterisk-22.8.2/main/stasis_bridges.c
+Index: asterisk-22.9.0/main/stasis_bridges.c
 ===================================================================
---- asterisk-22.8.2.orig/main/stasis_bridges.c
-+++ asterisk-22.8.2/main/stasis_bridges.c
+--- asterisk-22.9.0.orig/main/stasis_bridges.c
++++ asterisk-22.9.0/main/stasis_bridges.c
 @@ -37,6 +37,7 @@
  #include "asterisk/stasis_channels.h"
  #include "asterisk/bridge.h"
@@ -861,10 +861,10 @@ Index: asterisk-22.8.2/main/stasis_bridges.c
  
  	return res;
  }
-Index: asterisk-22.8.2/rest-api/api-docs/events.json
+Index: asterisk-22.9.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-22.8.2.orig/rest-api/api-docs/events.json
-+++ asterisk-22.8.2/rest-api/api-docs/events.json
+--- asterisk-22.9.0.orig/rest-api/api-docs/events.json
++++ asterisk-22.9.0/rest-api/api-docs/events.json
 @@ -173,6 +173,7 @@
  				"ApplicationUnregistered",
  				"ApplicationReplaced",

--- a/debian/patches/wazo_mixmonitor_events
+++ b/debian/patches/wazo_mixmonitor_events
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/apps/app_mixmonitor.c
+Index: asterisk-22.9.0/apps/app_mixmonitor.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_mixmonitor.c
-+++ asterisk-22.8.2/apps/app_mixmonitor.c
+--- asterisk-22.9.0.orig/apps/app_mixmonitor.c
++++ asterisk-22.9.0/apps/app_mixmonitor.c
 @@ -1082,6 +1082,8 @@ static int launch_monitor_thread(struct
  	struct mixmonitor *mixmonitor;
  	char postprocess2[1024] = "";
@@ -91,10 +91,10 @@ Index: asterisk-22.8.2/apps/app_mixmonitor.c
  	return 0;
  }
  
-Index: asterisk-22.8.2/main/cel.c
+Index: asterisk-22.9.0/main/cel.c
 ===================================================================
---- asterisk-22.8.2.orig/main/cel.c
-+++ asterisk-22.8.2/main/cel.c
+--- asterisk-22.9.0.orig/main/cel.c
++++ asterisk-22.9.0/main/cel.c
 @@ -344,6 +344,8 @@ static const char * const cel_event_type
  	[AST_CEL_STREAM_BEGIN]     = "STREAM_BEGIN",
  	[AST_CEL_STREAM_END]       = "STREAM_END",
@@ -104,7 +104,7 @@ Index: asterisk-22.8.2/main/cel.c
  };
  
  struct cel_backend {
-@@ -1420,6 +1422,33 @@ static void cel_pickup_cb(
+@@ -1447,6 +1449,33 @@ static void cel_pickup_cb(
  }
  
  
@@ -138,7 +138,7 @@ Index: asterisk-22.8.2/main/cel.c
  static void cel_local_optimization_cb_helper(
  	void *data, struct stasis_subscription *sub,
  	struct stasis_message *message,
-@@ -1603,6 +1632,16 @@ static int create_routes(void)
+@@ -1630,6 +1659,16 @@ static int create_routes(void)
  		NULL);
  
  	ret |= stasis_message_router_add(cel_state_router,
@@ -155,11 +155,11 @@ Index: asterisk-22.8.2/main/cel.c
  		ast_local_optimization_end_type(),
  		cel_local_optimization_end_cb,
  		NULL);
-Index: asterisk-22.8.2/include/asterisk/cel.h
+Index: asterisk-22.9.0/include/asterisk/cel.h
 ===================================================================
---- asterisk-22.8.2.orig/include/asterisk/cel.h
-+++ asterisk-22.8.2/include/asterisk/cel.h
-@@ -83,6 +83,10 @@ enum ast_cel_event_type {
+--- asterisk-22.9.0.orig/include/asterisk/cel.h
++++ asterisk-22.9.0/include/asterisk/cel.h
+@@ -84,6 +84,10 @@ enum ast_cel_event_type {
  	AST_CEL_STREAM_END = 20,
  	/*! \brief A DTMF digit was processed */
  	AST_CEL_DTMF = 21,

--- a/debian/patches/wazo_sip_mobility
+++ b/debian/patches/wazo_sip_mobility
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/res/res_pjsip/location.c
+Index: asterisk-22.9.0/res/res_pjsip/location.c
 ===================================================================
---- asterisk-22.8.2.orig/res/res_pjsip/location.c
-+++ asterisk-22.8.2/res/res_pjsip/location.c
+--- asterisk-22.9.0.orig/res/res_pjsip/location.c
++++ asterisk-22.9.0/res/res_pjsip/location.c
 @@ -355,7 +355,7 @@ struct ast_sip_contact *ast_sip_location
  struct ast_sip_contact *ast_sip_location_create_contact(struct ast_sip_aor *aor,
  	const char *uri, struct timeval expiration_time, const char *path_info,
@@ -41,10 +41,10 @@ Index: asterisk-22.8.2/res/res_pjsip/location.c
  
  	ast_sorcery_object_field_register(sorcery, "aor", "type", "", OPT_NOOP_T, 0, 0);
  	ast_sorcery_object_field_register(sorcery, "aor", "minimum_expiration", "60", OPT_UINT_T, 0, FLDSET(struct ast_sip_aor, minimum_expiration));
-Index: asterisk-22.8.2/res/res_pjsip_registrar.c
+Index: asterisk-22.9.0/res/res_pjsip_registrar.c
 ===================================================================
---- asterisk-22.8.2.orig/res/res_pjsip_registrar.c
-+++ asterisk-22.8.2/res/res_pjsip_registrar.c
+--- asterisk-22.9.0.orig/res/res_pjsip_registrar.c
++++ asterisk-22.9.0/res/res_pjsip_registrar.c
 @@ -625,6 +625,35 @@ static int vec_contact_add(void *obj, vo
  	return 0;
  }
@@ -190,10 +190,10 @@ Index: asterisk-22.8.2/res/res_pjsip_registrar.c
  	response_contact = ao2_callback(contacts, 0, NULL, NULL);
  
  	/* Send a response containing all of the contacts (including static) that are present on this AOR */
-Index: asterisk-22.8.2/include/asterisk/res_pjsip.h
+Index: asterisk-22.9.0/include/asterisk/res_pjsip.h
 ===================================================================
---- asterisk-22.8.2.orig/include/asterisk/res_pjsip.h
-+++ asterisk-22.8.2/include/asterisk/res_pjsip.h
+--- asterisk-22.9.0.orig/include/asterisk/res_pjsip.h
++++ asterisk-22.9.0/include/asterisk/res_pjsip.h
 @@ -409,6 +409,8 @@ struct ast_sip_contact {
  		AST_STRING_FIELD(call_id);
  		/*! The name of the endpoint that added the contact */
@@ -212,11 +212,11 @@ Index: asterisk-22.8.2/include/asterisk/res_pjsip.h
  
  /*!
   * \brief Update a contact
-Index: asterisk-22.8.2/res/res_pjsip/pjsip_config.xml
+Index: asterisk-22.9.0/res/res_pjsip/pjsip_config.xml
 ===================================================================
---- asterisk-22.8.2.orig/res/res_pjsip/pjsip_config.xml
-+++ asterisk-22.8.2/res/res_pjsip/pjsip_config.xml
-@@ -2735,6 +2735,12 @@
+--- asterisk-22.9.0.orig/res/res_pjsip/pjsip_config.xml
++++ asterisk-22.9.0/res/res_pjsip/pjsip_config.xml
+@@ -2747,6 +2747,12 @@
  						on a reliable transport and is not intended to be configured manually.
  					</para></description>
  				</configOption>

--- a/debian/patches/wazo_stun_recurring_resolution
+++ b/debian/patches/wazo_stun_recurring_resolution
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/main/dns_recurring.c
+Index: asterisk-22.9.0/main/dns_recurring.c
 ===================================================================
---- asterisk-22.8.2.orig/main/dns_recurring.c
-+++ asterisk-22.8.2/main/dns_recurring.c
+--- asterisk-22.9.0.orig/main/dns_recurring.c
++++ asterisk-22.9.0/main/dns_recurring.c
 @@ -41,9 +41,13 @@
  
  /*! \brief Delay between TTL expiration and the next DNS query, to make sure the
@@ -44,10 +44,10 @@ Index: asterisk-22.8.2/main/dns_recurring.c
  		}
  	}
  
-Index: asterisk-22.8.2/res/res_rtp_asterisk.c
+Index: asterisk-22.9.0/res/res_rtp_asterisk.c
 ===================================================================
---- asterisk-22.8.2.orig/res/res_rtp_asterisk.c
-+++ asterisk-22.8.2/res/res_rtp_asterisk.c
+--- asterisk-22.9.0.orig/res/res_rtp_asterisk.c
++++ asterisk-22.9.0/res/res_rtp_asterisk.c
 @@ -228,7 +228,7 @@ static int dtls_mtu = DEFAULT_DTLS_MTU;
  #ifdef HAVE_PJPROJECT
  static int icesupport = DEFAULT_ICESUPPORT;
@@ -93,7 +93,7 @@ Index: asterisk-22.8.2/res/res_rtp_asterisk.c
  #endif
  
  #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_SRTP)
-@@ -3745,7 +3748,7 @@ static void rtp_add_candidates_to_ice(st
+@@ -3757,7 +3760,7 @@ static void rtp_add_candidates_to_ice(st
  	pj_sockaddr pjtmp;
  	struct ast_ice_host_candidate *candidate;
  	int af_inet_ok = 0, af_inet6_ok = 0;
@@ -102,7 +102,7 @@ Index: asterisk-22.8.2/res/res_rtp_asterisk.c
  
  	if (ast_sockaddr_is_ipv4(addr)) {
  		af_inet_ok = 1;
-@@ -3855,9 +3858,7 @@ static void rtp_add_candidates_to_ice(st
+@@ -3867,9 +3870,7 @@ static void rtp_add_candidates_to_ice(st
  		freeifaddrs(ifa);
  	}
  
@@ -113,7 +113,7 @@ Index: asterisk-22.8.2/res/res_rtp_asterisk.c
  
  	/* If configured to use a STUN server to get our external mapped address do so */
  	if (stunaddr_copy.sin_addr.s_addr && !stun_address_is_blacklisted(addr) &&
-@@ -9614,70 +9615,175 @@ static int ast_rtp_bundle(struct ast_rtp
+@@ -9630,70 +9631,175 @@ static int ast_rtp_bundle(struct ast_rtp
  }
  
  #ifdef HAVE_PJPROJECT
@@ -335,7 +335,7 @@ Index: asterisk-22.8.2/res/res_rtp_asterisk.c
  }
  #endif
  
-@@ -9814,10 +9920,9 @@ static char *handle_cli_rtp_settings(str
+@@ -9830,10 +9936,9 @@ static char *handle_cli_rtp_settings(str
  #ifdef HAVE_PJPROJECT
  	ast_cli(a->fd, "  ICE support:     %s\n", AST_CLI_YESNO(icesupport));
  
@@ -349,7 +349,7 @@ Index: asterisk-22.8.2/res/res_rtp_asterisk.c
  #endif
  	return CLI_SUCCESS;
  }
-@@ -10066,7 +10171,8 @@ static int rtp_reload(int reload, int by
+@@ -10082,7 +10187,8 @@ static int rtp_reload(int reload, int by
  	icesupport = DEFAULT_ICESUPPORT;
  	stun_software_attribute = DEFAULT_STUN_SOFTWARE_ATTRIBUTE;
  	turnport = DEFAULT_TURN_PORT;
@@ -359,7 +359,7 @@ Index: asterisk-22.8.2/res/res_rtp_asterisk.c
  	turnaddr = pj_str(NULL);
  	turnusername = pj_str(NULL);
  	turnpassword = pj_str(NULL);
-@@ -10144,36 +10250,8 @@ static int rtp_reload(int reload, int by
+@@ -10160,36 +10266,8 @@ static int rtp_reload(int reload, int by
  		stun_software_attribute = ast_true(s);
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "stunaddr"))) {
@@ -398,7 +398,7 @@ Index: asterisk-22.8.2/res/res_rtp_asterisk.c
  	}
  	if ((s = ast_variable_retrieve(cfg, "general", "turnaddr"))) {
  		struct sockaddr_in addr;
-@@ -10439,7 +10517,7 @@ static int unload_module(void)
+@@ -10455,7 +10533,7 @@ static int unload_module(void)
  	acl_change_sub = stasis_unsubscribe_and_join(acl_change_sub);
  	rtp_unload_acl(&ice_acl_lock, &ice_acl);
  	rtp_unload_acl(&stun_acl_lock, &stun_acl);

--- a/debian/patches/xivo_agent_complete_ast11_compat
+++ b/debian/patches/xivo_agent_complete_ast11_compat
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -2545,6 +2545,18 @@ static struct ast_manager_event_blob *qu
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -2568,6 +2568,18 @@ static struct ast_manager_event_blob *qu
  			ast_log(LOG_NOTICE, "No caller event string, bailing\n");
  			return NULL;
  		}
@@ -21,7 +21,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	}
  
  	agent = ast_multi_channel_blob_get_channel(obj, "agent");
-@@ -6549,13 +6561,14 @@ static void send_agent_complete(const ch
+@@ -6582,13 +6594,14 @@ static void send_agent_complete(const ch
  		break;
  	}
  

--- a/debian/patches/xivo_agent_complete_wrapup
+++ b/debian/patches/xivo_agent_complete_wrapup
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -6532,7 +6532,7 @@ enum agent_complete_reason {
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -6565,7 +6565,7 @@ enum agent_complete_reason {
  /*! \brief Send out AMI message with member call completion status information */
  static void send_agent_complete(const char *queuename, struct ast_channel_snapshot *caller,
  	struct ast_channel_snapshot *peer, const struct member *member, time_t holdstart,
@@ -11,7 +11,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  {
  	const char *reason = NULL;	/* silence dumb compilers */
  	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
-@@ -6549,16 +6549,21 @@ static void send_agent_complete(const ch
+@@ -6582,16 +6582,21 @@ static void send_agent_complete(const ch
  		break;
  	}
  
@@ -34,7 +34,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  }
  
  static void queue_agent_cb(void *userdata, struct stasis_subscription *sub,
-@@ -6853,7 +6858,7 @@ static void handle_blind_transfer(void *
+@@ -6886,7 +6891,7 @@ static void handle_blind_transfer(void *
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -43,7 +43,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -6911,7 +6916,7 @@ static void handle_attended_transfer(voi
+@@ -6944,7 +6949,7 @@ static void handle_attended_transfer(voi
  	log_attended_transfer(queue_data, atxfer_msg);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,
@@ -52,7 +52,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	update_queue(queue_data->queue, queue_data->member, queue_data->callcompletedinsl,
  			queue_data->starttime);
  	remove_stasis_subscriptions(queue_data);
-@@ -7117,7 +7122,7 @@ static void handle_hangup(void *userdata
+@@ -7150,7 +7155,7 @@ static void handle_hangup(void *userdata
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
  	send_agent_complete(queue_data->queue->name, caller_snapshot, member_snapshot, queue_data->member,

--- a/debian/patches/xivo_ari_events_moh
+++ b/debian/patches/xivo_ari_events_moh
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/main/stasis_channels.c
+Index: asterisk-22.9.0/main/stasis_channels.c
 ===================================================================
---- asterisk-22.8.2.orig/main/stasis_channels.c
-+++ asterisk-22.8.2/main/stasis_channels.c
+--- asterisk-22.9.0.orig/main/stasis_channels.c
++++ asterisk-22.9.0/main/stasis_channels.c
 @@ -1823,6 +1823,47 @@ struct ast_ari_transfer_message *ast_ari
  	return msg;
  }
@@ -65,10 +65,10 @@ Index: asterisk-22.8.2/main/stasis_channels.c
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_start_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_stop_type);
  STASIS_MESSAGE_TYPE_DEFN(ast_channel_mixmonitor_mute_type);
-Index: asterisk-22.8.2/rest-api/api-docs/events.json
+Index: asterisk-22.9.0/rest-api/api-docs/events.json
 ===================================================================
---- asterisk-22.8.2.orig/rest-api/api-docs/events.json
-+++ asterisk-22.8.2/rest-api/api-docs/events.json
+--- asterisk-22.9.0.orig/rest-api/api-docs/events.json
++++ asterisk-22.9.0/rest-api/api-docs/events.json
 @@ -203,7 +203,9 @@
  				"ChannelConnectedLine",
  				"PeerStatusChange",
@@ -114,10 +114,10 @@ Index: asterisk-22.8.2/rest-api/api-docs/events.json
  		}
  	}
  }
-Index: asterisk-22.8.2/res/ari/ari_model_validators.c
+Index: asterisk-22.9.0/res/ari/ari_model_validators.c
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/ari_model_validators.c
-+++ asterisk-22.8.2/res/ari/ari_model_validators.c
+--- asterisk-22.9.0.orig/res/ari/ari_model_validators.c
++++ asterisk-22.9.0/res/ari/ari_model_validators.c
 @@ -4844,6 +4844,212 @@ ari_validator ast_ari_validate_channel_l
  	return ast_ari_validate_channel_left_bridge;
  }
@@ -357,10 +357,10 @@ Index: asterisk-22.8.2/res/ari/ari_model_validators.c
  	if (strcmp("ChannelStateChange", discriminator) == 0) {
  		return ast_ari_validate_channel_state_change(json);
  	} else
-Index: asterisk-22.8.2/res/ari/ari_model_validators.h
+Index: asterisk-22.9.0/res/ari/ari_model_validators.h
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/ari_model_validators.h
-+++ asterisk-22.8.2/res/ari/ari_model_validators.h
+--- asterisk-22.9.0.orig/res/ari/ari_model_validators.h
++++ asterisk-22.9.0/res/ari/ari_model_validators.h
 @@ -912,6 +912,38 @@ int ast_ari_validate_channel_left_bridge
  ari_validator ast_ari_validate_channel_left_bridge_fn(void);
  

--- a/debian/patches/xivo_ari_set_channel_var_bypass
+++ b/debian/patches/xivo_ari_set_channel_var_bypass
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/res/ari/resource_channels.c
+Index: asterisk-22.9.0/res/ari/resource_channels.c
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/resource_channels.c
-+++ asterisk-22.8.2/res/ari/resource_channels.c
+--- asterisk-22.9.0.orig/res/ari/resource_channels.c
++++ asterisk-22.9.0/res/ari/resource_channels.c
 @@ -1574,6 +1574,21 @@ void ast_ari_channels_set_channel_var(st
  		return;
  	}
@@ -24,10 +24,10 @@ Index: asterisk-22.8.2/res/ari/resource_channels.c
  	control = find_control(response, args->channel_id);
  	if (control == NULL) {
  		/* response filled in by find_control */
-Index: asterisk-22.8.2/res/ari/resource_channels.h
+Index: asterisk-22.9.0/res/ari/resource_channels.h
 ===================================================================
---- asterisk-22.8.2.orig/res/ari/resource_channels.h
-+++ asterisk-22.8.2/res/ari/resource_channels.h
+--- asterisk-22.9.0.orig/res/ari/resource_channels.h
++++ asterisk-22.9.0/res/ari/resource_channels.h
 @@ -706,6 +706,8 @@ struct ast_ari_channels_set_channel_var_
  	const char *variable;
  	/*! The value to set the variable to */
@@ -37,10 +37,10 @@ Index: asterisk-22.8.2/res/ari/resource_channels.h
  };
  /*!
   * \brief Body parsing function for /channels/{channelId}/variable.
-Index: asterisk-22.8.2/res/res_ari_channels.c
+Index: asterisk-22.9.0/res/res_ari_channels.c
 ===================================================================
---- asterisk-22.8.2.orig/res/res_ari_channels.c
-+++ asterisk-22.8.2/res/res_ari_channels.c
+--- asterisk-22.9.0.orig/res/res_ari_channels.c
++++ asterisk-22.9.0/res/res_ari_channels.c
 @@ -2484,6 +2484,10 @@ int ast_ari_channels_set_channel_var_par
  	if (field) {
  		args->value = ast_json_string_get(field);
@@ -62,10 +62,10 @@ Index: asterisk-22.8.2/res/res_ari_channels.c
  		{}
  	}
  	for (i = path_vars; i; i = i->next) {
-Index: asterisk-22.8.2/rest-api/api-docs/channels.json
+Index: asterisk-22.9.0/rest-api/api-docs/channels.json
 ===================================================================
---- asterisk-22.8.2.orig/rest-api/api-docs/channels.json
-+++ asterisk-22.8.2/rest-api/api-docs/channels.json
+--- asterisk-22.9.0.orig/rest-api/api-docs/channels.json
++++ asterisk-22.9.0/rest-api/api-docs/channels.json
 @@ -1601,6 +1601,15 @@
  							"required": false,
  							"allowMultiple": false,

--- a/debian/patches/xivo_ccss_exten_context_var
+++ b/debian/patches/xivo_ccss_exten_context_var
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/main/ccss.c
+Index: asterisk-22.9.0/main/ccss.c
 ===================================================================
---- asterisk-22.8.2.orig/main/ccss.c
-+++ asterisk-22.8.2/main/ccss.c
+--- asterisk-22.9.0.orig/main/ccss.c
++++ asterisk-22.9.0/main/ccss.c
 @@ -2698,6 +2698,8 @@ struct cc_generic_agent_pvt {
  static int cc_generic_agent_init(struct ast_cc_agent *agent, struct ast_channel *chan)
  {

--- a/debian/patches/xivo_channel_check_lock
+++ b/debian/patches/xivo_channel_check_lock
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/include/asterisk/channel.h
+Index: asterisk-22.9.0/include/asterisk/channel.h
 ===================================================================
---- asterisk-22.8.2.orig/include/asterisk/channel.h
-+++ asterisk-22.8.2/include/asterisk/channel.h
-@@ -4495,6 +4495,18 @@ int ast_channel_dialed_causes_add(const
+--- asterisk-22.9.0.orig/include/asterisk/channel.h
++++ asterisk-22.9.0/include/asterisk/channel.h
+@@ -4515,6 +4515,18 @@ int ast_channel_dialed_causes_add(const
   */
  void ast_channel_dialed_causes_clear(const struct ast_channel *chan);
  
@@ -21,11 +21,11 @@ Index: asterisk-22.8.2/include/asterisk/channel.h
  struct ast_flags *ast_channel_flags(struct ast_channel *chan);
  
  /*!
-Index: asterisk-22.8.2/main/channel.c
+Index: asterisk-22.9.0/main/channel.c
 ===================================================================
---- asterisk-22.8.2.orig/main/channel.c
-+++ asterisk-22.8.2/main/channel.c
-@@ -11079,3 +11079,34 @@ void ast_channel_clear_flag(struct ast_c
+--- asterisk-22.9.0.orig/main/channel.c
++++ asterisk-22.9.0/main/channel.c
+@@ -11119,3 +11119,34 @@ void ast_channel_clear_flag(struct ast_c
  	ast_channel_unlock(chan);
  }
  

--- a/debian/patches/xivo_dtmf_workaround_when_no_rtp
+++ b/debian/patches/xivo_dtmf_workaround_when_no_rtp
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/main/features.c
+Index: asterisk-22.9.0/main/features.c
 ===================================================================
---- asterisk-22.8.2.orig/main/features.c
-+++ asterisk-22.8.2/main/features.c
+--- asterisk-22.9.0.orig/main/features.c
++++ asterisk-22.9.0/main/features.c
 @@ -644,6 +644,14 @@ int ast_bridge_call_with_flags(struct as
  
  	ast_bridge_basic_set_flags(bridge, flags);

--- a/debian/patches/xivo_dtmf_xfer_plus
+++ b/debian/patches/xivo_dtmf_xfer_plus
@@ -1,7 +1,7 @@
-Index: asterisk-22.8.2/include/asterisk/file.h
+Index: asterisk-22.9.0/include/asterisk/file.h
 ===================================================================
---- asterisk-22.8.2.orig/include/asterisk/file.h
-+++ asterisk-22.8.2/include/asterisk/file.h
+--- asterisk-22.9.0.orig/include/asterisk/file.h
++++ asterisk-22.9.0/include/asterisk/file.h
 @@ -47,6 +47,7 @@ struct ast_format;
  #define AST_DIGIT_NONE ""
  #define AST_DIGIT_ANY "0123456789#*ABCD"
@@ -10,10 +10,10 @@ Index: asterisk-22.8.2/include/asterisk/file.h
  
  #define SEEK_FORCECUR	10
  
-Index: asterisk-22.8.2/main/bridge_basic.c
+Index: asterisk-22.9.0/main/bridge_basic.c
 ===================================================================
---- asterisk-22.8.2.orig/main/bridge_basic.c
-+++ asterisk-22.8.2/main/bridge_basic.c
+--- asterisk-22.9.0.orig/main/bridge_basic.c
++++ asterisk-22.9.0/main/bridge_basic.c
 @@ -3222,7 +3222,7 @@ static int grab_transfer(struct ast_chan
  
  	/* Play the simple "transfer" prompt out and wait */

--- a/debian/patches/xivo_queue_agent_talking
+++ b/debian/patches/xivo_queue_agent_talking
@@ -1,9 +1,9 @@
 Adding agent in conversation counter in QueueSummary AMI event (based on AST_DEVICE_INUSE flag)
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -10688,6 +10688,7 @@ static int manager_queues_summary(struct
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -10787,6 +10787,7 @@ static int manager_queues_summary(struct
  {
  	time_t now;
  	int qmemcount = 0;
@@ -11,7 +11,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int qmemavail = 0;
  	int qchancount = 0;
  	int qlongestholdtime = 0;
-@@ -10719,6 +10720,7 @@ static int manager_queues_summary(struct
+@@ -10818,6 +10819,7 @@ static int manager_queues_summary(struct
  		if (ast_strlen_zero(queuefilter) || !strcasecmp(q->name, queuefilter)) {
  			/* Reset the necessary local variables if no queuefilter is set*/
  			qmemcount = 0;
@@ -19,7 +19,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			qmemavail = 0;
  			qchancount = 0;
  			qlongestholdtime = 0;
-@@ -10732,6 +10734,9 @@ static int manager_queues_summary(struct
+@@ -10831,6 +10833,9 @@ static int manager_queues_summary(struct
  						++qmemavail;
  					}
  				}
@@ -29,7 +29,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				ao2_ref(mem, -1);
  			}
  			ao2_iterator_destroy(&mem_iter);
-@@ -10745,13 +10750,14 @@ static int manager_queues_summary(struct
+@@ -10844,13 +10849,14 @@ static int manager_queues_summary(struct
  				"Queue: %s\r\n"
  				"LoggedIn: %d\r\n"
  				"Available: %d\r\n"

--- a/debian/patches/xivo_queue_caller_leave_ast11_compat
+++ b/debian/patches/xivo_queue_caller_leave_ast11_compat
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -1879,6 +1879,7 @@ struct queue_ent {
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -1898,6 +1898,7 @@ struct queue_ent {
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
  	char digits[AST_MAX_EXTENSION];        /*!< Digits entered while in queue */
@@ -10,7 +10,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	const char *predial_callee;            /*!< Gosub app arguments for outgoing calls.  NULL if not supplied. */
  	int valid_digits;                      /*!< Digits entered correspond to valid extension. Exited */
  	int pos;                               /*!< Where we are in the queue */
-@@ -2428,6 +2429,20 @@ static struct ast_manager_event_blob *qu
+@@ -2451,6 +2452,20 @@ static struct ast_manager_event_blob *qu
  	RAII_VAR(struct ast_str *, event_string, NULL, ast_free);
  
  	channel_string = ast_manager_build_channel_state_string(obj->snapshot);
@@ -31,7 +31,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	event_string = ast_manager_str_from_json_object(obj->blob, NULL);
  	if (!channel_string || !event_string) {
  		return NULL;
-@@ -4793,10 +4808,11 @@ static void leave_queue(struct queue_ent
+@@ -4816,10 +4831,11 @@ static void leave_queue(struct queue_ent
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  			}
  
@@ -45,7 +45,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			ast_channel_publish_cached_blob(qe->chan, queue_caller_leave_type(), blob);
  			ast_debug(1, "Queue '%s' Leave, Channel '%s'\n", q->name, ast_channel_name(qe->chan));
  			/* Take us out of the queue */
-@@ -9112,6 +9128,8 @@ static int queue_exec(struct ast_channel
+@@ -9184,6 +9200,8 @@ static int queue_exec(struct ast_channel
  	} else {
  		raise_penalty = INT_MAX;
  	}

--- a/debian/patches/xivo_queue_digits_gender
+++ b/debian/patches/xivo_queue_digits_gender
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -4701,7 +4701,7 @@ static int say_position(struct queue_ent
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -4724,7 +4724,7 @@ static int say_position(struct queue_ent
  		}
  
  		if (avgholdmins >= 1) {
@@ -11,7 +11,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			if (res) {
  				goto playout;
  			}
-@@ -4719,7 +4719,7 @@ static int say_position(struct queue_ent
+@@ -4742,7 +4742,7 @@ static int say_position(struct queue_ent
  			}
  		}
  		if (avgholdsecs >= 1) {

--- a/debian/patches/xivo_queue_update_queue_before_agent_complete
+++ b/debian/patches/xivo_queue_update_queue_before_agent_complete
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -6886,10 +6886,10 @@ static void handle_blind_transfer(void *
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -6919,10 +6919,10 @@ static void handle_blind_transfer(void *
  			(long) (queue_data->starttime - queue_data->holdstart),
  			(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  
@@ -15,7 +15,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -6944,10 +6944,10 @@ static void handle_attended_transfer(voi
+@@ -6977,10 +6977,10 @@ static void handle_attended_transfer(voi
  	ast_debug(3, "Detected attended transfer in queue %s\n", queue_data->queue->name);
  	log_attended_transfer(queue_data, atxfer_msg);
  
@@ -28,7 +28,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	remove_stasis_subscriptions(queue_data);
  }
  
-@@ -7150,10 +7150,10 @@ static void handle_hangup(void *userdata
+@@ -7183,10 +7183,10 @@ static void handle_hangup(void *userdata
  		(long) (queue_data->starttime - queue_data->holdstart),
  		(long) (time(NULL) - queue_data->starttime), queue_data->caller_pos);
  

--- a/debian/patches/xivo_senddigit_begin
+++ b/debian/patches/xivo_senddigit_begin
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/main/channel.c
+Index: asterisk-22.9.0/main/channel.c
 ===================================================================
---- asterisk-22.8.2.orig/main/channel.c
-+++ asterisk-22.8.2/main/channel.c
-@@ -4895,7 +4895,24 @@ int ast_senddigit_begin(struct ast_chann
+--- asterisk-22.9.0.orig/main/channel.c
++++ asterisk-22.9.0/main/channel.c
+@@ -4935,7 +4935,24 @@ int ast_senddigit_begin(struct ast_chann
  	ast_channel_sending_dtmf_tv_set(chan, ast_tvnow());
  	ast_channel_unlock(chan);
  

--- a/debian/patches/xivo_skill_queues
+++ b/debian/patches/xivo_skill_queues
@@ -1,8 +1,8 @@
-Index: asterisk-22.8.2/apps/app_queue.c
+Index: asterisk-22.9.0/apps/app_queue.c
 ===================================================================
---- asterisk-22.8.2.orig/apps/app_queue.c
-+++ asterisk-22.8.2/apps/app_queue.c
-@@ -1695,6 +1695,8 @@ enum queue_reload_mask {
+--- asterisk-22.9.0.orig/apps/app_queue.c
++++ asterisk-22.9.0/apps/app_queue.c
+@@ -1714,6 +1714,8 @@ enum queue_reload_mask {
  	QUEUE_RELOAD_MEMBER = (1 << 1),
  	QUEUE_RELOAD_RULES = (1 << 2),
  	QUEUE_RESET_STATS = (1 << 3),
@@ -11,7 +11,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  };
  
  static const struct strategy {
-@@ -1865,9 +1867,14 @@ struct callattempt {
+@@ -1884,9 +1886,14 @@ struct callattempt {
  	char *orig_chan_name;
  };
  
@@ -26,7 +26,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	char moh[MAX_MUSICCLASS];              /*!< Name of musiconhold to be used */
  	char announce[PATH_MAX];               /*!< Announcement to play for member when call is answered */
  	char context[AST_MAX_CONTEXT];         /*!< Context when user exits queue */
-@@ -1890,8 +1897,11 @@ struct queue_ent {
+@@ -1909,8 +1916,11 @@ struct queue_ent {
  	int raise_respect_min;                 /*!< A switch raise_penalty should respect min_penalty not just max_penalty */
  	int linpos;                            /*!< If using linear strategy, what position are we at? */
  	int linwrapped;                        /*!< Is the linpos wrapped? */
@@ -38,7 +38,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int cancel_answered_elsewhere;         /*!< Whether we should force the CAE flag on this call (C) option*/
  	unsigned int withdraw:1;               /*!< Should this call exit the queue at its next iteration? Used for QueueWithdrawCaller */
  	char *withdraw_info;                   /*!< Optional info passed by the caller of QueueWithdrawCaller */
-@@ -1901,6 +1911,89 @@ struct queue_ent {
+@@ -1920,6 +1930,89 @@ struct queue_ent {
  	struct queue_ent *next;                /*!< The next queue entry */
  };
  
@@ -128,7 +128,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  struct member {
  	char interface[AST_CHANNEL_NAME];    /*!< Technology/Location to dial to reach this member*/
  	char state_exten[AST_MAX_EXTENSION]; /*!< Extension to get state from (if using hint) */
-@@ -1908,6 +2001,7 @@ struct member {
+@@ -1927,6 +2020,7 @@ struct member {
  	char state_interface[AST_CHANNEL_NAME]; /*!< Technology/Location from which to read devicestate changes */
  	int state_id;                        /*!< Extension state callback id (if using hint) */
  	char membername[80];                 /*!< Member name to use in queue logs */
@@ -136,7 +136,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int penalty;                         /*!< Are we a last resort? */
  	int calls;                           /*!< Number of calls serviced by this member */
  	int dynamic;                         /*!< Are we dynamically added? */
-@@ -1916,6 +2010,7 @@ struct member {
+@@ -1935,6 +2029,7 @@ struct member {
  	int paused;                          /*!< Are we paused (not accepting calls)? */
  	char reason_paused[80];              /*!< Reason of paused if member is paused */
  	int queuepos;                        /*!< In what order (pertains to certain strategies) should this member be called? */
@@ -144,7 +144,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int callcompletedinsl;               /*!< Whether the current call was completed within service level */
  	int wrapuptime;                      /*!< Wrapup Time */
  	time_t starttime;                    /*!< The time at which the member answered the current caller. */
-@@ -2063,6 +2158,7 @@ struct call_queue {
+@@ -2086,6 +2181,7 @@ struct call_queue {
  
  	int log_restricted_caller_id:1;     /*!< Whether log Restricted Caller ID */
  
@@ -152,7 +152,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	struct ao2_container *members;      /*!< Head of the list of members */
  	struct queue_ent *head;             /*!< Head of the list of callers */
  	AST_LIST_ENTRY(call_queue) list;    /*!< Next call queue */
-@@ -2085,6 +2181,40 @@ static int set_member_paused(const char
+@@ -2108,6 +2204,40 @@ static int set_member_paused(const char
  static int update_queue(struct call_queue *q, struct member *member, int callcompletedinsl, time_t starttime);
  
  static struct member *find_member_by_queuename_and_interface(const char *queuename, const char *interface);
@@ -193,7 +193,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  /*! \brief sets the QUEUESTATUS channel variable */
  static void set_queue_result(struct ast_channel *chan, enum queue_result res)
  {
-@@ -2573,7 +2703,7 @@ static void queue_publish_member_blob(st
+@@ -2596,7 +2726,7 @@ static void queue_publish_member_blob(st
  
  static struct ast_json *queue_member_blob_create(struct call_queue *q, struct member *mem)
  {
@@ -202,7 +202,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		"Queue", q->name,
  		"MemberName", mem->membername,
  		"Interface", mem->interface,
-@@ -2589,7 +2719,8 @@ static struct ast_json *queue_member_blo
+@@ -2612,7 +2742,8 @@ static struct ast_json *queue_member_blo
  		"Paused", mem->paused,
  		"PausedReason", mem->reason_paused,
  		"Ringinuse", mem->ringinuse,
@@ -212,7 +212,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  }
  
  /*! \brief Check if members are available
-@@ -2598,7 +2729,7 @@ static struct ast_json *queue_member_blo
+@@ -2621,7 +2752,7 @@ static struct ast_json *queue_member_blo
   * is available, the function immediately returns 0. If no members are available,
   * then -1 is returned.
   */
@@ -221,7 +221,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  {
  	struct member *member;
  	struct ao2_iterator mem_iter;
-@@ -2623,6 +2754,11 @@ static int get_member_status(struct call
+@@ -2646,6 +2777,11 @@ static int get_member_status(struct call
  			}
  		}
  
@@ -233,7 +233,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		switch (devstate ? ast_device_state(member->state_interface) : member->status) {
  		case AST_DEVICE_INVALID:
  			if (conditions & QUEUE_EMPTY_INVALID) {
-@@ -2681,7 +2817,7 @@ static int get_member_status(struct call
+@@ -2704,7 +2840,7 @@ static int get_member_status(struct call
  
  	if (!devstate && (conditions & QUEUE_EMPTY_RINGING)) {
  		/* member state still may be RINGING due to lag in event message - check again with device state */
@@ -242,7 +242,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	}
  	return -1;
  }
-@@ -2777,6 +2913,7 @@ static void update_status(struct call_qu
+@@ -2800,6 +2936,7 @@ static void update_status(struct call_qu
  		 */
  		pending_members_remove(m);
  
@@ -250,7 +250,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		queue_publish_member_blob(queue_member_status_type(), queue_member_blob_create(q, m));
  	}
  }
-@@ -2787,7 +2924,7 @@ static void update_status(struct call_qu
+@@ -2810,7 +2947,7 @@ static void update_status(struct call_qu
   * \retval 1 if the member is available
   * \retval 0 if the member is not available
   */
@@ -259,7 +259,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  {
  	int available = 0;
  	int wrapuptime;
-@@ -2807,7 +2944,8 @@ static int is_member_available(struct ca
+@@ -2830,7 +2967,8 @@ static int is_member_available(struct ca
  			/* else fall through */
  		case AST_DEVICE_NOT_INUSE:
  		case AST_DEVICE_UNKNOWN:
@@ -269,7 +269,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				available = 1;
  			}
  			break;
-@@ -2868,7 +3006,7 @@ static void device_state_cb(void *unused
+@@ -2891,7 +3029,7 @@ static void device_state_cb(void *unused
  
  			/* check every member until we find one NOT_INUSE */
  			if (!avail) {
@@ -278,7 +278,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			}
  			if (avail && found_member) {
  				/* early exit as we've found an available member and the member of interest */
-@@ -3046,7 +3184,7 @@ static void destroy_queue_member_cb(void
+@@ -3069,7 +3207,7 @@ static void destroy_queue_member_cb(void
  }
  
  /*! \brief allocate space for new queue member and set fields based on parameters passed */
@@ -287,7 +287,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  {
  	struct member *cur;
  
-@@ -3085,6 +3223,10 @@ static struct member *create_queue_membe
+@@ -3108,6 +3246,10 @@ static struct member *create_queue_membe
  			cur->state_id = -1;
  		}
  		cur->status = get_queue_member_status(cur);
@@ -298,7 +298,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	}
  
  	return cur;
-@@ -3793,6 +3935,7 @@ static void rt_handle_member_record(stru
+@@ -3816,6 +3958,7 @@ static void rt_handle_member_record(stru
  	const char *paused_str = ast_variable_retrieve(member_config, category, "paused");
  	const char *wrapuptime_str = ast_variable_retrieve(member_config, category, "wrapuptime");
  	const char *reason_paused = ast_variable_retrieve(member_config, category, "reason_paused");
@@ -306,7 +306,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  	if (ast_strlen_zero(rt_uniqueid)) {
  		ast_log(LOG_WARNING, "Realtime field 'uniqueid' is empty for member %s\n",
-@@ -3857,6 +4000,11 @@ static void rt_handle_member_record(stru
+@@ -3880,6 +4023,11 @@ static void rt_handle_member_record(stru
  				ast_copy_string(m->state_interface, state_interface, sizeof(m->state_interface));
  			}
  			m->penalty = penalty;
@@ -318,7 +318,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			m->ringinuse = ringinuse;
  			m->wrapuptime = wrapuptime;
  			if (realtime_reason_paused) {
-@@ -3864,6 +4012,7 @@ static void rt_handle_member_record(stru
+@@ -3887,6 +4035,7 @@ static void rt_handle_member_record(stru
  			}
  			found = 1;
  			ao2_ref(m, -1);
@@ -326,7 +326,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			break;
  		}
  		ao2_ref(m, -1);
-@@ -3872,9 +4021,10 @@ static void rt_handle_member_record(stru
+@@ -3895,9 +4044,10 @@ static void rt_handle_member_record(stru
  
  	/* Create a new member */
  	if (!found) {
@@ -338,7 +338,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			ast_copy_string(m->rt_uniqueid, rt_uniqueid, sizeof(m->rt_uniqueid));
  			if (!ast_strlen_zero(reason_paused)) {
  				ast_copy_string(m->reason_paused, reason_paused, sizeof(m->reason_paused));
-@@ -3921,6 +4071,10 @@ static void destroy_queue(void *obj)
+@@ -3944,6 +4094,10 @@ static void destroy_queue(void *obj)
  		}
  	}
  	ao2_ref(q->members, -1);
@@ -349,7 +349,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  }
  
  static struct call_queue *alloc_queue(const char *queuename)
-@@ -4255,6 +4409,34 @@ static void update_realtime_members(stru
+@@ -4278,6 +4432,34 @@ static void update_realtime_members(stru
  	ast_config_destroy(member_config);
  }
  
@@ -384,7 +384,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  static int join_queue(char *queuename, struct queue_ent *qe, enum queue_result *reason, int position)
  {
  	struct call_queue *q;
-@@ -4271,7 +4453,7 @@ static int join_queue(char *queuename, s
+@@ -4294,7 +4476,7 @@ static int join_queue(char *queuename, s
  	/* This is our one */
  	if (q->joinempty) {
  		int status = 0;
@@ -393,7 +393,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			*reason = QUEUE_JOINEMPTY;
  			ao2_unlock(q);
  			queue_t_unref(q, "Done with realtime queue");
-@@ -4288,6 +4470,10 @@ static int join_queue(char *queuename, s
+@@ -4311,6 +4493,10 @@ static int join_queue(char *queuename, s
  		 * Take into account the priority of the calling user */
  		inserted = 0;
  		prev = NULL;
@@ -404,7 +404,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		cur = q->head;
  		while (cur) {
  			/* We have higher priority than the current user, enter
-@@ -4320,6 +4506,7 @@ static int join_queue(char *queuename, s
+@@ -4343,6 +4529,7 @@ static int join_queue(char *queuename, s
  		ast_copy_string(qe->announce, q->announce, sizeof(qe->announce));
  		ast_copy_string(qe->context, q->context, sizeof(qe->context));
  		q->count++;
@@ -412,7 +412,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		if (q->count == 1) {
  			ast_devstate_changed(AST_DEVICE_RINGING, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  		}
-@@ -4405,7 +4592,7 @@ static int valid_exit(struct queue_ent *
+@@ -4428,7 +4615,7 @@ static int valid_exit(struct queue_ent *
  
  static int say_position(struct queue_ent *qe, int ringing)
  {
@@ -421,7 +421,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	long avgholdmins, avgholdsecs;
  	time_t now;
  
-@@ -4462,11 +4649,12 @@ static int say_position(struct queue_ent
+@@ -4485,11 +4672,12 @@ static int say_position(struct queue_ent
  		}
  	}
  	/* Round hold time to nearest minute */
@@ -436,7 +436,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		avgholdsecs *= qe->parent->roundingseconds;
  	} else {
  		avgholdsecs = 0;
-@@ -4587,6 +4775,8 @@ static void leave_queue(struct queue_ent
+@@ -4610,6 +4798,8 @@ static void leave_queue(struct queue_ent
  			RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
  			char posstr[20];
  			q->count--;
@@ -445,7 +445,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			if (!q->count) {
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s", q->name);
  			}
-@@ -4703,9 +4893,10 @@ static void hangupcalls(struct queue_ent
+@@ -4726,9 +4916,10 @@ static void hangupcalls(struct queue_ent
   * \note The queue passed in should be locked prior to this function call
   *
   * \param[in] q The queue for which we are counting the number of available members
@@ -457,7 +457,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  {
  	struct member *mem;
  	int avl = 0;
-@@ -4714,7 +4905,7 @@ static int num_available_members(struct
+@@ -4737,7 +4928,7 @@ static int num_available_members(struct
  	mem_iter = ao2_iterator_init(q->members, 0);
  	while ((mem = ao2_iterator_next(&mem_iter))) {
  
@@ -466,7 +466,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		ao2_ref(mem, -1);
  
  		/* If autofill is not enabled or if the queue's strategy is ringall, then
-@@ -4755,7 +4946,7 @@ static int compare_weight(struct call_qu
+@@ -4778,7 +4969,7 @@ static int compare_weight(struct call_qu
  		if (q->count && q->members) {
  			if ((mem = ao2_find(q->members, member, OBJ_POINTER))) {
  				ast_debug(1, "Found matching member %s in queue '%s'\n", mem->interface, q->name);
@@ -475,7 +475,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  					ast_debug(1, "Queue '%s' (weight %d, calls %d) is preferred over '%s' (weight %d, calls %d)\n", q->name, q->weight, q->count, rq->name, rq->weight, rq->count);
  					found = 1;
  				}
-@@ -4853,7 +5044,7 @@ static int member_status_available(int s
+@@ -4886,7 +5077,7 @@ static int member_status_available(int s
   *
   * \retval non-zero if an entry can be called.
   */
@@ -484,7 +484,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  {
  	struct member *memberp = call->member;
  	int wrapuptime;
-@@ -4880,6 +5071,13 @@ static int can_ring_entry(struct queue_e
+@@ -4913,6 +5104,13 @@ static int can_ring_entry(struct queue_e
  		return 0;
  	}
  
@@ -498,7 +498,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	if (use_weight && compare_weight(qe->parent, memberp)) {
  		ast_debug(1, "Priority queue delaying call to %s:%s\n",
  			qe->parent->name, call->interface);
-@@ -4959,7 +5157,7 @@ static int ring_entry(struct queue_ent *
+@@ -4992,7 +5190,7 @@ static int ring_entry(struct queue_ent *
  	RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
  
  	/* on entry here, we know that tmp->chan == NULL */
@@ -507,7 +507,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		tmp->stillgoing = 0;
  		++*busies;
  		return 0;
-@@ -5950,14 +6148,14 @@ static int is_our_turn(struct queue_ent
+@@ -5983,14 +6181,14 @@ static int is_our_turn(struct queue_ent
  	/* This needs a lock. How many members are available to be served? */
  	ao2_lock(qe->parent);
  
@@ -524,7 +524,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			idx++;
  		}
  		ch = ch->next;
-@@ -6107,7 +6305,7 @@ static int wait_our_turn(struct queue_en
+@@ -6140,7 +6338,7 @@ static int wait_our_turn(struct queue_en
  		if (qe->parent->leavewhenempty) {
  			int status = 0;
  
@@ -533,7 +533,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				record_abandoned(qe);
  				*reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(qe->parent->name, ast_channel_uniqueid(qe->chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe->pos, qe->opos, (long) (time(NULL) - qe->start));
-@@ -6159,6 +6357,13 @@ static int wait_our_turn(struct queue_en
+@@ -6192,6 +6390,13 @@ static int wait_our_turn(struct queue_en
  			*reason = QUEUE_TIMEOUT;
  			break;
  		}
@@ -547,7 +547,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	}
  
  	return res;
-@@ -7400,6 +7605,7 @@ static int try_calling(struct queue_ent
+@@ -7462,6 +7667,7 @@ static int try_calling(struct queue_ent
  		ao2_unlock(qe->parent);
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
@@ -555,7 +555,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		hangupcalls(qe, outgoing, peer, qe->cancel_answered_elsewhere);
  		outgoing = NULL;
  		if (announce || qe->parent->reportholdtime || qe->parent->memberdelay) {
-@@ -7686,7 +7892,7 @@ static struct member *interface_exists(s
+@@ -7751,7 +7957,7 @@ static struct member *interface_exists(s
  
  /*! \brief Dump all members in a specific queue to the database
   * \code
@@ -564,7 +564,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
   * \endcode
   */
  static void dump_queue_members(struct call_queue *pm_queue)
-@@ -7712,13 +7918,14 @@ static void dump_queue_members(struct ca
+@@ -7777,13 +7983,14 @@ static void dump_queue_members(struct ca
  			continue;
  		}
  
@@ -580,7 +580,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			cur_member->reason_paused,
  			cur_member->wrapuptime);
  
-@@ -7750,6 +7957,7 @@ static int remove_from_queue(const char
+@@ -7815,6 +8022,7 @@ static int remove_from_queue(const char
  		.name = queuename,
  	};
  	struct member *mem, tmpmem;
@@ -588,7 +588,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int res = RES_NOSUCHQUEUE;
  
  	ast_copy_string(tmpmem.interface, interface, sizeof(tmpmem.interface));
-@@ -7769,13 +7977,20 @@ static int remove_from_queue(const char
+@@ -7834,13 +8042,20 @@ static int remove_from_queue(const char
  			queue_publish_member_blob(queue_member_removed_type(), queue_member_blob_create(q, mem));
  
  			member_remove_from_queue(q, mem);
@@ -610,7 +610,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -7797,7 +8012,7 @@ static int remove_from_queue(const char
+@@ -7862,7 +8077,7 @@ static int remove_from_queue(const char
   * \retval RES_EXISTS queue exists but no members
   * \retval RES_OUT_OF_MEMORY queue exists but not enough memory to create member
  */
@@ -619,7 +619,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  {
  	struct call_queue *q;
  	struct member *new_member, *old_member;
-@@ -7811,15 +8026,16 @@ static int add_to_queue(const char *queu
+@@ -7876,15 +8091,16 @@ static int add_to_queue(const char *queu
  
  	ao2_lock(q);
  	if ((old_member = interface_exists(q, interface)) == NULL) {
@@ -638,7 +638,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
  
-@@ -8035,10 +8251,10 @@ static void set_queue_member_pause(struc
+@@ -8100,10 +8316,10 @@ static void set_queue_member_pause(struc
  		dump_queue_members(q);
  	}
  
@@ -651,7 +651,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		ast_devstate_changed(AST_DEVICE_INUSE, AST_DEVSTATE_CACHABLE,
  			"Queue:%s_avail", q->name);
  	}
-@@ -8053,6 +8269,7 @@ static void set_queue_member_pause(struc
+@@ -8118,6 +8334,7 @@ static void set_queue_member_pause(struc
  
  	ast_queue_log(q->name, "NONE", mem->membername, paused ? "PAUSE" : "UNPAUSE",
  		"%s", mem->reason_paused);
@@ -659,7 +659,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  	publish_queue_member_pause(q, mem);
  
-@@ -8316,6 +8533,7 @@ static void reload_queue_members(void)
+@@ -8381,6 +8598,7 @@ static void reload_queue_members(void)
  	char *member;
  	char *interface;
  	char *membername = NULL;
@@ -667,7 +667,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	char *state_interface;
  	char *penalty_tok;
  	int penalty = 0;
-@@ -8370,6 +8588,7 @@ static void reload_queue_members(void)
+@@ -8435,6 +8653,7 @@ static void reload_queue_members(void)
  			paused_tok = strsep(&member, ";");
  			membername = strsep(&member, ";");
  			state_interface = strsep(&member, ";");
@@ -675,7 +675,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			reason_paused = strsep(&member, ";");
  			wrapuptime_tok = strsep(&member, ";");
  
-@@ -8404,7 +8623,7 @@ static void reload_queue_members(void)
+@@ -8469,7 +8688,7 @@ static void reload_queue_members(void)
  			ast_debug(1, "Reload Members: Queue: %s  Member: %s  Name: %s  Penalty: %d  Paused: %d ReasonPause: %s  Wrapuptime: %d\n",
  			              queue_name, interface, membername, penalty, paused, reason_paused, wrapuptime);
  
@@ -684,7 +684,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				ast_log(LOG_ERROR, "Out of Memory when reloading persistent queue member\n");
  				break;
  			}
-@@ -8575,6 +8794,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8640,6 +8859,7 @@ static int aqm_exec(struct ast_channel *
  		AST_APP_ARG(membername);
  		AST_APP_ARG(state_interface);
  		AST_APP_ARG(wrapuptime);
@@ -692,7 +692,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	);
  	int penalty = 0;
  	int paused = 0;
-@@ -8582,7 +8802,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8647,7 +8867,7 @@ static int aqm_exec(struct ast_channel *
  	struct ast_flags flags = { 0 };
  
  	if (ast_strlen_zero(data)) {
@@ -701,7 +701,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8627,7 +8847,7 @@ static int aqm_exec(struct ast_channel *
+@@ -8692,7 +8912,7 @@ static int aqm_exec(struct ast_channel *
  		wrapuptime = 0;
  	}
  
@@ -710,7 +710,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(args.membername) || !log_membername_as_agent) {
  			ast_queue_log(args.queuename, ast_channel_uniqueid(chan), args.interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -8762,6 +8982,7 @@ static int queue_exec(struct ast_channel
+@@ -8827,6 +9047,7 @@ static int queue_exec(struct ast_channel
  		AST_APP_ARG(gosub);
  		AST_APP_ARG(rule);
  		AST_APP_ARG(position);
@@ -718,8 +718,8 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	);
  	/* Our queue entry */
  	struct queue_ent qe = { 0 };
-@@ -8771,7 +8992,7 @@ static int queue_exec(struct ast_channel
- 	int cid_allow;
+@@ -8843,7 +9064,7 @@ static int queue_exec(struct ast_channel
+ 	pbx_builtin_setvar_helper(chan, "QUEUEWAIT_MS", "");
  
  	if (ast_strlen_zero(data)) {
 -		ast_log(LOG_WARNING, "Queue requires an argument: queuename[,options[,URL[,announceoverride[,timeout[,agi[,gosub[,rule[,position]]]]]]]]\n");
@@ -727,7 +727,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		return -1;
  	}
  
-@@ -8903,6 +9124,9 @@ static int queue_exec(struct ast_channel
+@@ -8975,6 +9196,9 @@ static int queue_exec(struct ast_channel
  	qe.max_penalty = max_penalty;
  	qe.min_penalty = min_penalty;
  	qe.raise_penalty = raise_penalty;
@@ -737,7 +737,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	qe.last_pos_said = 0;
  	qe.last_pos = 0;
  	qe.last_periodic_announce_time = time(NULL);
-@@ -8978,6 +9202,18 @@ check_turns:
+@@ -9050,6 +9274,18 @@ check_turns:
  		ast_moh_start(chan, qe.moh, NULL);
  	}
  
@@ -756,7 +756,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	/* This is the wait loop for callers 2 through maxlen */
  	res = wait_our_turn(&qe, ringing, &reason);
  	if (res) {
-@@ -9055,7 +9291,7 @@ check_turns:
+@@ -9127,7 +9363,7 @@ check_turns:
  
  		if (qe.parent->leavewhenempty) {
  			int status = 0;
@@ -765,7 +765,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  				record_abandoned(&qe);
  				reason = QUEUE_LEAVEEMPTY;
  				ast_queue_log(args.queuename, ast_channel_uniqueid(chan), "NONE", "EXITEMPTY", "%d|%d|%ld", qe.pos, qe.opos, (long)(time(NULL) - qe.start));
-@@ -9157,6 +9393,16 @@ stop:
+@@ -9250,6 +9486,16 @@ stop:
  	if (reason != QUEUE_UNKNOWN)
  		set_queue_result(chan, reason);
  
@@ -782,7 +782,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	/*
  	 * every queue_ent is given a reference to it's parent
  	 * call_queue when it joins the queue.  This ref must be taken
-@@ -9831,6 +10077,7 @@ static void queue_reset_global_params(vo
+@@ -9924,6 +10170,7 @@ static void queue_reset_global_params(vo
  	log_unpause_on_reason_change = 0;
  }
  
@@ -790,7 +790,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  /*! Set the global queue parameters as defined in the "general" section of queues.conf */
  static void queue_set_global_params(struct ast_config *cfg)
  {
-@@ -9876,7 +10123,7 @@ static void queue_set_global_params(stru
+@@ -9975,7 +10222,7 @@ static void queue_set_global_params(stru
   */
  static void reload_single_member(const char *memberdata, struct call_queue *q)
  {
@@ -799,7 +799,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	char *parse;
  	struct member *cur, *newm;
  	struct member tmpmem;
-@@ -9892,6 +10139,7 @@ static void reload_single_member(const c
+@@ -9991,6 +10238,7 @@ static void reload_single_member(const c
  		AST_APP_ARG(ringinuse);
  		AST_APP_ARG(wrapuptime);
  		AST_APP_ARG(paused);
@@ -807,7 +807,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	);
  
  	if (ast_strlen_zero(memberdata)) {
-@@ -9946,6 +10194,10 @@ static void reload_single_member(const c
+@@ -10045,6 +10293,10 @@ static void reload_single_member(const c
  		ringinuse = q->ringinuse;
  	}
  
@@ -818,7 +818,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	if (!ast_strlen_zero(args.wrapuptime)) {
  		tmp = args.wrapuptime;
  		ast_strip(tmp);
-@@ -9980,7 +10232,7 @@ static void reload_single_member(const c
+@@ -10079,7 +10331,7 @@ static void reload_single_member(const c
  		paused = cur->paused;
  	}
  
@@ -827,7 +827,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		newm->wrapuptime = wrapuptime;
  		if (cur) {
  			ao2_lock(q->members);
-@@ -10000,6 +10252,7 @@ static void reload_single_member(const c
+@@ -10099,6 +10351,7 @@ static void reload_single_member(const c
  		ao2_ref(newm, -1);
  	}
  	newm = NULL;
@@ -835,7 +835,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  	if (cur) {
  		ao2_ref(cur, -1);
-@@ -10288,6 +10541,12 @@ static int reload_handler(int reload, st
+@@ -10387,6 +10640,12 @@ static int reload_handler(int reload, st
  	if (ast_test_flag(mask, QUEUE_RELOAD_RULES)) {
  		res |= reload_queue_rules(reload);
  	}
@@ -848,7 +848,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	if (ast_test_flag(mask, QUEUE_RESET_STATS)) {
  		res |= clear_stats(queuename);
  	}
-@@ -10376,6 +10635,8 @@ static void print_queue(struct mansessio
+@@ -10475,6 +10734,8 @@ static void print_queue(struct mansessio
  					mem->status == AST_DEVICE_UNAVAILABLE || mem->status == AST_DEVICE_UNKNOWN ?
  						COLOR_RED : COLOR_GREEN, COLOR_BLACK),
  					ast_devstate2str(mem->status), ast_term_reset());
@@ -857,7 +857,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			if (mem->calls) {
  				ast_str_append(&out, 0, " has taken %d calls (last was %ld secs ago)",
  					mem->calls, (long) (now - mem->lastcall));
-@@ -10397,8 +10658,32 @@ static void print_queue(struct mansessio
+@@ -10496,8 +10757,32 @@ static void print_queue(struct mansessio
  		struct queue_ent *qe;
  		int pos = 1;
  
@@ -890,7 +890,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  			ast_str_set(&out, 0, "      %d. %s (wait: %ld:%2.2ld, prio: %d)",
  				pos++, ast_channel_name(qe->chan), (long) (now - qe->start) / 60,
  				(long) (now - qe->start) % 60, qe->prio);
-@@ -10848,11 +11133,12 @@ static int manager_queues_status(struct
+@@ -10947,11 +11232,12 @@ static int manager_queues_status(struct
  						"Paused: %d\r\n"
  						"PausedReason: %s\r\n"
  						"Wrapuptime: %d\r\n"
@@ -904,7 +904,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  					++q_items;
  				}
  				ao2_ref(mem, -1);
-@@ -10897,7 +11183,7 @@ static int manager_queues_status(struct
+@@ -10996,7 +11282,7 @@ static int manager_queues_status(struct
  
  static int manager_add_queue_member(struct mansession *s, const struct message *m)
  {
@@ -913,7 +913,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int paused, penalty, wrapuptime = 0;
  
  	queuename = astman_get_header(m, "Queue");
-@@ -10908,6 +11194,7 @@ static int manager_add_queue_member(stru
+@@ -11007,6 +11293,7 @@ static int manager_add_queue_member(stru
  	membername = astman_get_header(m, "MemberName");
  	state_interface = astman_get_header(m, "StateInterface");
  	wrapuptime_s = astman_get_header(m, "Wrapuptime");
@@ -921,7 +921,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  
  	if (ast_strlen_zero(queuename)) {
  		astman_send_error(s, m, "'Queue' not specified.");
-@@ -10937,7 +11224,7 @@ static int manager_add_queue_member(stru
+@@ -11036,7 +11323,7 @@ static int manager_add_queue_member(stru
  		paused = abs(ast_true(paused_s));
  	}
  
@@ -930,7 +930,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "MANAGER", interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -11068,6 +11355,14 @@ static int manager_queue_reload(struct m
+@@ -11167,6 +11454,14 @@ static int manager_queue_reload(struct m
  		ast_set_flag(&mask, QUEUE_RELOAD_RULES);
  		header_found = 1;
  	}
@@ -945,7 +945,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	if (!strcasecmp(S_OR(astman_get_header(m, "Parameters"), ""), "yes")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
  		header_found = 1;
-@@ -11277,7 +11572,7 @@ static int manager_request_withdraw_call
+@@ -11376,7 +11671,7 @@ static int manager_request_withdraw_call
  
  static char *handle_queue_add_member(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
  {
@@ -954,7 +954,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	int penalty, paused = 0;
  
  	switch ( cmd ) {
-@@ -11291,7 +11586,7 @@ static char *handle_queue_add_member(str
+@@ -11390,7 +11685,7 @@ static char *handle_queue_add_member(str
  		return complete_queue_add_member(a->line, a->word, a->pos, a->n);
  	}
  
@@ -963,7 +963,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  		return CLI_SHOWUSAGE;
  	} else if (strcmp(a->argv[4], "to")) {
  		return CLI_SHOWUSAGE;
-@@ -11303,6 +11598,8 @@ static char *handle_queue_add_member(str
+@@ -11402,6 +11697,8 @@ static char *handle_queue_add_member(str
  		return CLI_SHOWUSAGE;
  	} else if ((a->argc == 14) && strcmp(a->argv[12], "paused")) {
  		return CLI_SHOWUSAGE;
@@ -972,7 +972,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	}
  
  	queuename = a->argv[5];
-@@ -11334,7 +11631,11 @@ static char *handle_queue_add_member(str
+@@ -11433,7 +11730,11 @@ static char *handle_queue_add_member(str
  		reason = a->argv[13];
  	}
  
@@ -985,7 +985,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	case RES_OKAY:
  		if (ast_strlen_zero(membername) || !log_membername_as_agent) {
  			ast_queue_log(queuename, "CLI", interface, "ADDMEMBER", "%s", paused ? "PAUSED" : "");
-@@ -11864,6 +12165,10 @@ static char *handle_queue_reload(struct
+@@ -11963,6 +12264,10 @@ static char *handle_queue_reload(struct
  		ast_set_flag(&mask, QUEUE_RELOAD_MEMBER);
  	} else if (!strcasecmp(a->argv[2], "parameters")) {
  		ast_set_flag(&mask, QUEUE_RELOAD_PARAMETERS);
@@ -996,7 +996,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  	} else if (!strcasecmp(a->argv[2], "all")) {
  		ast_set_flag(&mask, AST_FLAGS_ALL & ~QUEUE_RESET_STATS);
  	}
-@@ -11960,6 +12265,1182 @@ static int qupd_exec(struct ast_channel
+@@ -12059,6 +12364,1182 @@ static int qupd_exec(struct ast_channel
  	return 0;
  }
  
@@ -2179,7 +2179,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  static struct ast_cli_entry cli_queue[] = {
  	AST_CLI_DEFINE(queue_show, "Show status of a specified queue"),
  	AST_CLI_DEFINE(handle_queue_rule_show, "Show the rules defined in queuerules.conf"),
-@@ -11971,11 +13452,10 @@ static struct ast_cli_entry cli_queue[]
+@@ -12070,11 +13551,10 @@ static struct ast_cli_entry cli_queue[]
  	AST_CLI_DEFINE(handle_queue_reload, "Reload queues, members, queue rules, or parameters"),
  	AST_CLI_DEFINE(handle_queue_reset, "Reset statistics for a queue"),
  	AST_CLI_DEFINE(handle_queue_change_priority_caller, "Change priority caller on queue"),
@@ -2193,7 +2193,7 @@ Index: asterisk-22.8.2/apps/app_queue.c
  static int unload_module(void)
  {
  	stasis_message_router_unsubscribe_and_join(agent_router);
-@@ -12207,32 +13687,6 @@ static int load_module(void)
+@@ -12306,32 +13786,6 @@ static int load_module(void)
  	return AST_MODULE_LOAD_SUCCESS;
  }
  
@@ -2226,10 +2226,10 @@ Index: asterisk-22.8.2/apps/app_queue.c
  AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
  	.support_level = AST_MODULE_SUPPORT_CORE,
  	.load = load_module,
-Index: asterisk-22.8.2/configs/samples/queueskillrules.conf.sample
+Index: asterisk-22.9.0/configs/samples/queueskillrules.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-22.8.2/configs/samples/queueskillrules.conf.sample
++++ asterisk-22.9.0/configs/samples/queueskillrules.conf.sample
 @@ -0,0 +1,63 @@
 +; This file describes skill routing rules. The Queue() application can get the
 +; 'skill_ruleset' argument which is the name of one skill routing ruleset. If
@@ -2294,10 +2294,10 @@ Index: asterisk-22.8.2/configs/samples/queueskillrules.conf.sample
 +; [client-cool]
 +; rule => EWT < 120, technic = 0 & (sympathy > 60)
 +; rule => technic = 0
-Index: asterisk-22.8.2/configs/samples/queueskills.conf.sample
+Index: asterisk-22.9.0/configs/samples/queueskills.conf.sample
 ===================================================================
 --- /dev/null
-+++ asterisk-22.8.2/configs/samples/queueskills.conf.sample
++++ asterisk-22.9.0/configs/samples/queueskills.conf.sample
 @@ -0,0 +1,46 @@
 +; Describe skills groups here to assign them to queue members. You can set
 +; weight to each skills. It'll be used by skill rules to know if a queue member


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core telephony paths (PJSIP reload serialization, RTP resource cleanup, queue locking/shared state) on a full minor bump with many rebased Wazo patches; regressions could affect calls, registration, and agent queues.
> 
> **Overview**
> Bumps the Wazo Debian package to **Asterisk 22.9.0** and rebases the existing patch set from `22.8.2` to `22.9.0` paths.
> 
> **New upstream backports** (added to `debian/patches/series`):
> - **PJSIP config reload** runs on the PJSIP serializer via `ast_sip_push_task_wait_servant` instead of calling `ast_sorcery_reload` directly, avoiding reload deadlocks.
> - **RTP ioqueue teardown** calls `pj_ioqueue_destroy` before releasing the pool, fixing an FD leak on ioqueue thread destroy.
> 
> The **queue deadlock** patch is refreshed for 22.9.0: queue members that share the same interface across queues use a **`shared_info`** block (mutex + shared `lastcall` / calls / wrap-up state) with getter/updater helpers so `shared_lastcall` behavior stays consistent without the old cross-queue iterator in `update_queue`.
> 
> Everything else in the diff is mostly **line/context rebases** (Wazo ARI, bridges, MOH, MixMonitor CEL, PJSIP mobility, STUN, skill queues, `chan_pjsip` channel-var deadlock fix, etc.) plus **changelog** entries for `8:22.9.0-1~wazo1` through `~wazo3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4145ae7ccdbae93529f64c3b39ff111cf9d5c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->